### PR TITLE
Add prefetching to links

### DIFF
--- a/app/c/[cid]/add-problem/problem-form.tsx
+++ b/app/c/[cid]/add-problem/problem-form.tsx
@@ -93,7 +93,7 @@ export default function ProblemForm({
   return (
     <div className="p-8 text-slate-800 whitespace-pre-wrap break-words">
       <div className="mb-8 sm:mb-16 inline-block">
-        <Link href={`/c/${collection.cid}`} className="text-slate-600 hover:text-slate-800 underline flex items-center">
+        <Link href={`/c/${collection.cid}`} prefetch={true} className="text-slate-600 hover:text-slate-800 underline flex items-center">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
           </svg>

--- a/app/c/[cid]/p/[pid]/problem-page.tsx
+++ b/app/c/[cid]/p/[pid]/problem-page.tsx
@@ -37,7 +37,7 @@ export default function ProblemPage(props: Props) {
   return (
     <div className="p-8 text-slate-800 whitespace-pre-wrap break-words">
       <div className="mb-8 sm:mb-16 inline-block">
-        <Link href={`/c/${collection.cid}`} className="text-slate-600 hover:text-slate-800 underline flex items-center">
+        <Link href={`/c/${collection.cid}`} prefetch={true} className="text-slate-600 hover:text-slate-800 underline flex items-center">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
           </svg>

--- a/app/c/[cid]/page.tsx
+++ b/app/c/[cid]/page.tsx
@@ -139,7 +139,6 @@ async function getCollection(cid: string): Promise<CollectionProps> {
     })
   }
   problems.sort(sortByNew);
-  console.log(problems);
 
   collection.problems = problems;
   return collection;

--- a/app/c/[cid]/problem-card.tsx
+++ b/app/c/[cid]/problem-card.tsx
@@ -52,7 +52,7 @@ export default function ProblemCard({
   const titleLineColor = titleLineColors[subjectColor];
 
   return (
-    <Link href={`/c/${collection.cid}/p/${problem.pid}`}>
+    <Link href={`/c/${collection.cid}/p/${problem.pid}`} prefetch={true}>
       <div className="bg-white p-8 my-8 rounded-2xl soft-shadow-xl">
         <h2 className="text-2xl sm:text-3xl font-bold text-slate-900 mb-4">{problem.title}</h2>
         <div className={`w-16 h-2 mb-4 ${titleLineColor} rounded-full`}></div>

--- a/app/c/[cid]/problem-list.tsx
+++ b/app/c/[cid]/problem-list.tsx
@@ -30,7 +30,7 @@ export default function ProblemList({
       <div className="w-128 sm:w-144 md:w-160 max-w-full mx-auto">
         <div className="flex flex-wrap gap-x-12 gap-y-6 mb-12">
           {/* TODO: blue shadow */}
-          <Link href={`/c/${collection.cid}/add-problem`} className="shrink-0 grow inline-block py-3 px-10 text-center rounded-xl bg-blue-500 hover:bg-blue-600 text-slate-50 font-bold text-base soft-shadow-xl">Add Problem</Link>
+          <Link href={`/c/${collection.cid}/add-problem`} prefetch={true} className="shrink-0 grow inline-block py-3 px-10 text-center rounded-xl bg-blue-500 hover:bg-blue-600 text-slate-50 font-bold text-base soft-shadow-xl">Add Problem</Link>
           <div className="grow-[1000]">
             <div className="relative text-slate-600">
               <form>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -27,7 +27,7 @@ export default function Sidebar({
         <div className="flex flex-col justify-between flex-1">
           <nav>
             {links.map(({ href, label, active }) => (
-              <Link key={href} href={href} className={`flex items-center p-3 px-6 my-2 rounded-lg ${active ? "bg-slate-100 text-slate-700" : "text-slate-600 hover:bg-slate-100 hover:text-slate-700 transition-colors duration-300"}`}>
+              <Link key={href} href={href} prefetch={true} className={`flex items-center p-3 px-6 my-2 rounded-lg ${active ? "bg-slate-100 text-slate-700" : "text-slate-600 hover:bg-slate-100 hover:text-slate-700 transition-colors duration-300"}`}>
                 <span className="font-medium">{label}</span>
               </Link>
             ))}


### PR DESCRIPTION
According to [NextJS docs](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#1-prefetching):

> For dynamic routes, prefetch defaults to automatic. Only the shared layout down until the first loading.js file is prefetched and cached for 30s

This explicitly sets `prefetch` to `true` instead of leaving it `null` (which will default to `automatic`)