### PR TITLE
Sort by least testsolved first

### DIFF
--- a/app/c/[cid]/page.tsx
+++ b/app/c/[cid]/page.tsx
@@ -61,9 +61,9 @@ async function getCollection(cid: string): Promise<CollectionProps> {
         // String to Date (because JSON doesn't have Date)
         problem.createdAt = new Date(problem.createdAt);
       }
-    })
+    });
+    problems.sort(sortByNew);
   }
-  problems.sort(sortByNew);
 
   collection.problems = problems;
   return collection;

--- a/pages/api/internal/collections/[id]/problems/get.ts
+++ b/pages/api/internal/collections/[id]/problems/get.ts
@@ -16,9 +16,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const problems = await prisma.problem.findMany({
       where: { collectionId },
-      orderBy: {
-        id: 'desc'
-      },
+      orderBy: [
+        {
+          solveAttempts: {
+            _count: 'asc'
+          }
+        },
+        {
+          createdAt: 'desc'
+        },
+      ],
       include: {  // TODO: match ProblemProps in [cid]/types
         authors: {
           select: {


### PR DESCRIPTION
The default sorting order should show the least testsolved problems first, to encourage an equal spread of testsolves per problem.