### PR TITLE
Disable DaisyUI dark theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
         },
       },
     ],
+    darkTheme: "light",
     logs: false,
   },
 };


### PR DESCRIPTION
Dark mode isn't implemented yet. But it seems like it's being applies to parts of the site (can only reproduce in safari on an ipad mini)