### PR TITLE
Migration adding Permission.testsolveLock

### DIFF
--- a/prisma/migrations/20241007010839_add_permission_testsolve_lock/migration.sql
+++ b/prisma/migrations/20241007010839_add_permission_testsolve_lock/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Permission" ADD COLUMN     "testsolveLock" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,7 +152,7 @@ model Permission {
   collectionId           Int
   accessLevel            AccessLevel @default(TeamMember)
   createdAt              DateTime    @default(now())
-  testsolveLock          Boolean?
+  testsolveLock          Boolean?  // true = serious testsolver, false = casual
   testsolveLockStartedAt DateTime?  // if collection.requireTestsolve is true, any problems created after this time cannot be viewed without testsolving
 
   @@unique([userId, collectionId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,7 @@ model Permission {
   collectionId           Int
   accessLevel            AccessLevel @default(TeamMember)
   createdAt              DateTime    @default(now())
+  testsolveLock          Boolean?
   testsolveLockStartedAt DateTime?  // if collection.requireTestsolve is true, any problems created after this time cannot be viewed without testsolving
 
   @@unique([userId, collectionId])


### PR DESCRIPTION
boolean which determines if the member is a serious or casual testsolver (or neither)