### PR TITLE
chore: add automated testing with vitest

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: verify
-description: Verify a change is done by running lint, the Prettier check, and a production build. Use after finishing any code change and before opening a PR, since this repo has no test suite.
+description: Verify a change is done by running lint, the Prettier check, the test suites, and a production build. Use after finishing any code change and before opening a PR.
 ---
 
-Run these three checks from the repo root, in order, and stop at the first failure:
+Run these checks from the repo root, in order, and stop at the first failure:
 
 ```
 npm run lint
 npx prettier . --check
+npm test
+npm run test:db && npm run test:integration
 npm run build
 ```
 
 - If Prettier reports unformatted files, run `npx prettier --write <files>` on just those files and re-run the check.
 - If lint or build fails, fix the reported issue. `@typescript-eslint/no-floating-promises` is an error: add `.catch(...)` or `void` to un-awaited promises rather than disabling the rule.
+- `npm run test:db` needs Docker. If Docker is unavailable, skip the integration step and say so explicitly in the report; do not point the tests at any other database.
+- If a test fails, decide whether the test or the code is wrong before changing either, and say which in the report.
 - Report the outcome faithfully: which checks passed, and the exact error output for any that failed.
 
 Do not run `npm run dev:prod` or `npm run prod` as part of verification.

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# Loaded explicitly by `npm run test:integration` / `npm run test:all` (via dotenv-cli).
+# Points at the throwaway container from docker-compose.test.yml. No secrets here.
+# The test setup refuses to run against any database whose name does not end in `_test`.
+NODE_ENV=test
+DATABASE_URL=postgres://postgres:postgres@localhost:5433/probase_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  unit:
+    name: Unit and component tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: probase_test
+        # Same port and credentials as docker-compose.test.yml, so .env.test works unchanged.
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d probase_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run test:integration

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 # env files
 .env*
 !.env.example
+!.env.test
 
 # vercel
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Env files are never loaded implicitly. Prefix DB/Prisma commands with the env wrapper:
   `npm run local -- prisma migrate dev`, `npm run local -- prisma db seed`.
-- Verification before calling a change done (there are no tests): `npm run lint`, `npx prettier . --check`, `npm run build`. CI only runs the Prettier check.
+- Verification before calling a change done: `npm run lint`, `npx prettier . --check`, `npm test`, `npm run test:integration` (needs `npm run test:db` first), `npm run build`. CI runs the Prettier check plus both test suites.
 - Seed script is `prisma/seed.mjs` (plain JS, run by `prisma db seed`).
+
+## Tests
+
+- Vitest, configured in `vitest.config.mts` (must stay `.mts`: the package is CommonJS and Vitest's CJS entry can't load on Node 22.8). Three projects: `unit` (`test/unit/**/*.test.ts`), `components` (`test/unit/**/*.test.tsx`, happy-dom + Testing Library), `integration` (`test/integration/**/*.test.ts`).
+- Integration tests hit a real Postgres (`docker-compose.test.yml`, port 5433, `.env.test`). They mock only `auth()` and `next/cache`; use `signInAs()` from `test/integration/session.ts` and the row builders in `test/integration/factories.ts`. Every table is truncated before each test, so the global setup refuses any database whose name doesn't end in `_test`. Never point `.env.test` at the dev or prod database.
+- `redirect()` / `notFound()` throw; assert them with `expectRedirect()` / `expectNotFound()` from `test/integration/navigation.ts`.
+- When adding a server action, add an integration test for its auth and permission failures as well as its happy path.
 
 ## Production safety
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ npm run dev
 
 The website should now be running at <http://localhost:3000>
 
+## Testing
+
+Tests use [Vitest](https://vitest.dev) and live under `test/`.
+
+- `npm test` runs the unit tests (`test/unit/**/*.test.ts`, pure functions in `lib/`) and the component tests (`test/unit/**/*.test.tsx`, React components rendered with Testing Library). No database needed.
+- `npm run test:integration` runs the server actions and API routes against a real Postgres database (`test/integration/`). Start the throwaway database first with `npm run test:db` (Docker, port 5433, separate from your dev database). Migrations are applied automatically, and every table is truncated before each test. Stop it with `npm run test:db:down`.
+- `npm run test:all` runs everything. `npm run test:watch` watches the unit and component tests.
+
+Integration tests mock only `auth()` (see `test/integration/session.ts`) and `next/cache`; everything else, including Prisma, is real. Row builders live in `test/integration/factories.ts`. As a safety net, the integration setup refuses to run against any database whose name does not end in `_test`.
+
+Both suites run in GitHub Actions on every pull request.
+
 ## Contributing
 
 Anyone is welcome to contribute!

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,20 @@
+# Throwaway Postgres for the integration tests (`npm run test:db`).
+# Runs on port 5433 so it never collides with the local dev database on 5432.
+# Data lives in tmpfs: stopping the container wipes it.
+services:
+  db:
+    image: postgres:16
+    container_name: probase-test-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: probase_test
+    ports:
+      - "5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d probase_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
       "scripts",
       "types",
       "prisma",
+      "test",
       "auth.ts",
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,17 +30,22 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.7",
         "@types/katex": "^0.16.7",
         "@types/node": "~22.8.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
+        "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.20",
         "dotenv-cli": "^7.4.2",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.0.1",
         "eslint-config-prettier": "^9.1.0",
+        "happy-dom": "^20.14.0",
         "postcss": "^8.4.47",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.8",
@@ -48,7 +53,8 @@
         "tailwindcss": "^3.4.14",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -60,6 +66,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -70,6 +83,71 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@auth/core": {
       "version": "0.37.2",
@@ -114,6 +192,348 @@
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -134,6 +554,158 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -425,6 +997,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
@@ -471,6 +1060,23 @@
       "optional": true,
       "os": [
         "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ],
       "engines": {
         "node": ">=18"
@@ -776,16 +1382,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -796,26 +1410,37 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
-      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@next/env": {
@@ -1390,6 +2015,363 @@
         }
       }
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1401,6 +2383,13 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1418,6 +2407,154 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1444,10 +2581,88 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1496,6 +2711,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1711,6 +2943,140 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1741,6 +3107,18 @@
       "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1975,6 +3353,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2060,6 +3448,18 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2119,6 +3519,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/busboy": {
@@ -2188,6 +3601,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2304,6 +3727,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -2332,6 +3762,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2341,6 +3794,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -2355,6 +3838,34 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -2427,6 +3938,15 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2467,6 +3987,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2498,6 +4029,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -2564,6 +4103,21 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2673,6 +4227,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -3312,6 +4873,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3319,6 +4890,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3530,6 +5111,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -3667,6 +5258,48 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/happy-dom": {
+      "version": "20.14.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.0.tgz",
+      "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -3748,6 +5381,68 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3781,6 +5476,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4060,6 +5765,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -4272,6 +5986,61 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4441,11 +6210,41 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "devOptional": true
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4466,6 +6265,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4516,15 +6325,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4794,6 +6604,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4864,6 +6688,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4911,6 +6750,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4954,9 +6800,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4973,8 +6819,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -5312,6 +7158,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5329,6 +7185,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5369,6 +7239,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5478,6 +7360,61 @@
         "node": "*"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5534,6 +7471,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5642,6 +7603,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5661,6 +7629,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -5867,6 +7849,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5953,6 +7948,15 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tailwind-merge": {
       "version": "2.5.4",
@@ -6044,6 +8048,105 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6054,6 +8157,36 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6348,6 +8481,736 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6444,6 +9307,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -6538,6 +9418,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -6545,11 +9468,18 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "start": "next start",
     "launch": "next build && next start",
     "lint": "next lint",
+    "test": "vitest run --project unit --project components",
+    "test:watch": "vitest --project unit --project components",
+    "test:db": "docker compose -f docker-compose.test.yml up -d --wait",
+    "test:db:down": "docker compose -f docker-compose.test.yml down",
+    "test:integration": "dotenv -e .env.test -- vitest run --project integration",
+    "test:all": "dotenv -e .env.test -- vitest run",
     "local": "dotenv -e .env.local --",
     "prod": "tsx scripts/prod.ts",
     "postinstall": "prisma generate"
@@ -38,17 +44,22 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/katex": "^0.16.7",
     "@types/node": "~22.8.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.20",
     "dotenv-cli": "^7.4.2",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.0.1",
     "eslint-config-prettier": "^9.1.0",
+    "happy-dom": "^20.14.0",
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",
@@ -56,7 +67,8 @@
     "tailwindcss": "^3.4.14",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.11"
   },
   "packageManager": "npm@10.8.2"
 }

--- a/test/integration/actions/add-problem.test.ts
+++ b/test/integration/actions/add-problem.test.ts
@@ -1,0 +1,206 @@
+import { revalidateTag } from "next/cache";
+import { describe, expect, it } from "vitest";
+import { addProblem } from "@/app/c/[cid]/add-problem/actions";
+import prisma from "@/lib/prisma";
+import { error } from "@/lib/server-actions";
+import {
+  createAuthor,
+  createCollection,
+  createPermission,
+  createProblem,
+  createUser,
+} from "../factories";
+import { expectRedirect } from "../navigation";
+import { signInAs, signOut } from "../session";
+
+function problemForm(fields: Record<string, string>): FormData {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    form.set(key, value);
+  }
+  return form;
+}
+
+async function setup(accessLevel: "Admin" | "TeamMember" | "SubmitOnly") {
+  const collection = await createCollection();
+  const user = await createUser();
+  await createPermission(user, collection, accessLevel);
+  const author = await createAuthor(collection, { userId: user.id });
+  signInAs(user);
+  const fields = {
+    title: "Sum of squares",
+    subject: "Algebra",
+    statement: "Find $1^2 + 2^2$.",
+    answer: "5",
+    solution: "",
+    authorId: String(author.id),
+    difficulty: "3",
+  };
+  return { collection, user, author, fields };
+}
+
+describe("addProblem", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await addProblem(1, problemForm({}))).toEqual(
+      error("Not signed in"),
+    );
+  });
+
+  it("rejects an unknown collection", async () => {
+    const { fields } = await setup("Admin");
+
+    expect(await addProblem(999, problemForm(fields))).toEqual(
+      error("Collection not found"),
+    );
+  });
+
+  it("rejects a user without permission on the collection", async () => {
+    const { collection, fields } = await setup("Admin");
+    const stranger = await createUser();
+    signInAs(stranger);
+
+    expect(await addProblem(collection.id, problemForm(fields))).toEqual(
+      error("You do not have permission to add a problem"),
+    );
+    expect(await prisma.problem.count()).toBe(0);
+  });
+
+  it("rejects a ViewOnly user", async () => {
+    const { collection, fields } = await setup("Admin");
+    const viewer = await createUser();
+    await createPermission(viewer, collection, "ViewOnly");
+    signInAs(viewer);
+
+    expect(await addProblem(collection.id, problemForm(fields))).toEqual(
+      error("You do not have permission to add a problem"),
+    );
+  });
+
+  it.each(["Admin", "TeamMember", "SubmitOnly"] as const)(
+    "lets a %s add a problem and redirects to it",
+    async (level) => {
+      const { collection, fields } = await setup(level);
+
+      await expectRedirect(
+        addProblem(collection.id, problemForm(fields)),
+        `/c/${collection.cid}/p/A1`,
+      );
+      expect(await prisma.problem.count()).toBe(1);
+    },
+  );
+
+  it("stores every field, attributes the author, and self-likes", async () => {
+    const { collection, user, author, fields } = await setup("TeamMember");
+
+    await expectRedirect(
+      addProblem(collection.id, problemForm(fields)),
+      `/c/${collection.cid}/p/A1`,
+    );
+
+    const problem = await prisma.problem.findUniqueOrThrow({
+      where: { collectionId_pid: { collectionId: collection.id, pid: "A1" } },
+      include: { authors: true, solutions: true, likes: true },
+    });
+    expect(problem).toMatchObject({
+      title: "Sum of squares",
+      subject: "Algebra",
+      statement: "Find $1^2 + 2^2$.",
+      answer: "5",
+      difficulty: 3,
+      isAnonymous: false,
+      isArchived: false,
+      submitterId: user.id,
+    });
+    expect(problem.authors.map((a) => a.id)).toEqual([author.id]);
+    expect(problem.solutions).toEqual([]);
+    expect(problem.likes).toEqual([{ userId: user.id, problemId: problem.id }]);
+    expect(revalidateTag).toHaveBeenCalledWith(
+      `collection/${collection.cid}/problems`,
+    );
+  });
+
+  it("creates a solution by the same author when one is given", async () => {
+    const { collection, author, fields } = await setup("TeamMember");
+
+    await expectRedirect(
+      addProblem(
+        collection.id,
+        problemForm({ ...fields, solution: "$1 + 4 = 5$." }),
+      ),
+      `/c/${collection.cid}/p/A1`,
+    );
+
+    const solutions = await prisma.solution.findMany({
+      include: { authors: true },
+    });
+    expect(solutions).toHaveLength(1);
+    expect(solutions[0].text).toBe("$1 + 4 = 5$.");
+    expect(solutions[0].authors.map((a) => a.id)).toEqual([author.id]);
+  });
+
+  describe("problem id generation", () => {
+    it("numbers each subject independently from 1", async () => {
+      const { collection, fields } = await setup("Admin");
+
+      await expectRedirect(
+        addProblem(
+          collection.id,
+          problemForm({ ...fields, subject: "Algebra" }),
+        ),
+        `/c/${collection.cid}/p/A1`,
+      );
+      await expectRedirect(
+        addProblem(
+          collection.id,
+          problemForm({ ...fields, subject: "NumberTheory" }),
+        ),
+        `/c/${collection.cid}/p/N1`,
+      );
+      await expectRedirect(
+        addProblem(
+          collection.id,
+          problemForm({ ...fields, subject: "Combinatorics" }),
+        ),
+        `/c/${collection.cid}/p/C1`,
+      );
+      await expectRedirect(
+        addProblem(
+          collection.id,
+          problemForm({ ...fields, subject: "Geometry" }),
+        ),
+        `/c/${collection.cid}/p/G1`,
+      );
+      await expectRedirect(
+        addProblem(
+          collection.id,
+          problemForm({ ...fields, subject: "Algebra" }),
+        ),
+        `/c/${collection.cid}/p/A2`,
+      );
+    });
+
+    it("increments the most recently created id in the subject", async () => {
+      const { collection, fields } = await setup("Admin");
+      await createProblem(collection, { pid: "A7", subject: "Algebra" });
+      await createProblem(collection, { pid: "A9", subject: "Algebra" });
+
+      await expectRedirect(
+        addProblem(collection.id, problemForm(fields)),
+        `/c/${collection.cid}/p/A10`,
+      );
+    });
+
+    it("does not look at other collections", async () => {
+      const { collection, fields } = await setup("Admin");
+      const other = await createCollection();
+      await createProblem(other, { pid: "A5", subject: "Algebra" });
+
+      await expectRedirect(
+        addProblem(collection.id, problemForm(fields)),
+        `/c/${collection.cid}/p/A1`,
+      );
+    });
+  });
+});

--- a/test/integration/actions/invite.test.ts
+++ b/test/integration/actions/invite.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import { acceptInvite } from "@/app/invite/[code]/actions";
+import prisma from "@/lib/prisma";
+import { error } from "@/lib/server-actions";
+import {
+  createCollection,
+  createInvite,
+  createPermission,
+  createUser,
+} from "../factories";
+import { expectRedirect } from "../navigation";
+import { signInAs, signOut } from "../session";
+
+async function permissionFor(user: { id: string }, collection: { id: number }) {
+  return prisma.permission.findUnique({
+    where: {
+      userId_collectionId: { userId: user.id, collectionId: collection.id },
+    },
+  });
+}
+
+describe("acceptInvite", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await acceptInvite("anything")).toEqual(error("Not signed in"));
+  });
+
+  it("rejects a session without an email", async () => {
+    const user = await createUser();
+    signInAs({ id: user.id, email: null });
+
+    expect(await acceptInvite("anything")).toEqual(
+      error("session.email is null or undefined"),
+    );
+  });
+
+  it("rejects an unknown invite code", async () => {
+    signInAs(await createUser());
+
+    expect(await acceptInvite("no-such-code")).toEqual(
+      error("Invalid invite code"),
+    );
+  });
+
+  it("rejects an expired invite", async () => {
+    const collection = await createCollection();
+    const inviter = await createUser();
+    const invite = await createInvite(collection, inviter, {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const user = await createUser();
+    signInAs(user);
+
+    expect(await acceptInvite(invite.code)).toEqual(
+      error("Invite has expired"),
+    );
+    expect(await permissionFor(user, collection)).toBeNull();
+  });
+
+  it("grants the invite's access level and redirects to the collection", async () => {
+    const collection = await createCollection();
+    const inviter = await createUser();
+    const invite = await createInvite(collection, inviter, {
+      accessLevel: "ViewOnly",
+    });
+    const user = await createUser();
+    signInAs(user);
+
+    await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+
+    expect(await permissionFor(user, collection)).toMatchObject({
+      accessLevel: "ViewOnly",
+      testsolverType: null,
+      seriousTestsolverStartedAt: null,
+    });
+  });
+
+  it("upgrades an existing permission to the invite's access level", async () => {
+    const collection = await createCollection();
+    const inviter = await createUser();
+    const invite = await createInvite(collection, inviter, {
+      accessLevel: "Admin",
+    });
+    const user = await createUser();
+    await createPermission(user, collection, "ViewOnly");
+    signInAs(user);
+
+    await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+
+    expect((await permissionFor(user, collection))?.accessLevel).toBe("Admin");
+    expect(await prisma.permission.count()).toBe(1);
+  });
+
+  describe("email domain restriction", () => {
+    it("rejects an email outside the domain", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        emailDomain: "mit.edu",
+      });
+      const user = await createUser({ email: "student@harvard.edu" });
+      signInAs(user);
+
+      expect(await acceptInvite(invite.code)).toEqual(
+        error("Invalid email domain"),
+      );
+    });
+
+    it("does not accept a lookalike domain suffix", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        emailDomain: "mit.edu",
+      });
+      const user = await createUser({ email: "student@notmit.edu" });
+      signInAs(user);
+
+      expect(await acceptInvite(invite.code)).toEqual(
+        error("Invalid email domain"),
+      );
+    });
+
+    it("accepts an email in the domain", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        emailDomain: "mit.edu",
+      });
+      const user = await createUser({ email: "student@mit.edu" });
+      signInAs(user);
+
+      await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+      expect(await permissionFor(user, collection)).not.toBeNull();
+    });
+  });
+
+  describe("one-time-use invites", () => {
+    it("expires after the first accept", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        oneTimeUse: true,
+      });
+      const first = await createUser();
+      const second = await createUser();
+
+      signInAs(first);
+      await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+      const used = await prisma.invite.findUniqueOrThrow({
+        where: { code: invite.code },
+      });
+      expect(used.expiresAt).not.toBeNull();
+
+      signInAs(second);
+      expect(await acceptInvite(invite.code)).toEqual(
+        error("Invite has expired"),
+      );
+      expect(await permissionFor(second, collection)).toBeNull();
+    });
+
+    it("a reusable invite keeps working", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        oneTimeUse: false,
+      });
+
+      for (let i = 0; i < 2; i++) {
+        signInAs(await createUser());
+        await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+      }
+      expect(await prisma.permission.count()).toBe(2);
+    });
+  });
+
+  describe("collections that force serious testsolving", () => {
+    it.each(["topsoj", "mgci"])(
+      "makes new members of %s serious testsolvers from the collection's creation",
+      async (cid) => {
+        const collection = await createCollection({ cid });
+        const inviter = await createUser();
+        const invite = await createInvite(collection, inviter);
+        const user = await createUser();
+        signInAs(user);
+
+        await expectRedirect(acceptInvite(invite.code), `/c/${cid}`);
+
+        expect(await permissionFor(user, collection)).toMatchObject({
+          testsolverType: "Serious",
+          seriousTestsolverStartedAt: collection.createdAt,
+        });
+      },
+    );
+
+    it("leaves the testsolver type unset for other collections", async () => {
+      const collection = await createCollection({ cid: "topsoj-2" });
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter);
+      const user = await createUser();
+      signInAs(user);
+
+      await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+
+      expect(
+        (await permissionFor(user, collection))?.testsolverType,
+      ).toBeNull();
+    });
+  });
+});

--- a/test/integration/actions/problem.test.ts
+++ b/test/integration/actions/problem.test.ts
@@ -1,0 +1,409 @@
+import { revalidateTag } from "next/cache";
+import { describe, expect, it, vi } from "vitest";
+import {
+  addComment,
+  addSolution,
+  editProblem,
+  editSolution,
+  likeProblem,
+} from "@/app/c/[cid]/p/[pid]/actions";
+import prisma from "@/lib/prisma";
+import { error } from "@/lib/server-actions";
+import {
+  createAuthor,
+  createCollection,
+  createPermission,
+  createProblem,
+  createSolution,
+  createUser,
+} from "../factories";
+import { signInAs, signOut } from "../session";
+
+describe("likeProblem", () => {
+  it("rejects a signed-out user", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    signOut();
+
+    expect(await likeProblem(problem.id, true)).toEqual(error("Not signed in"));
+  });
+
+  it("rejects an unknown problem", async () => {
+    const user = await createUser();
+    signInAs(user);
+
+    expect(await likeProblem(999, true)).toEqual(
+      error("No problem with id 999"),
+    );
+  });
+
+  it("rejects a user without permission on the collection", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    signInAs(user);
+
+    expect(await likeProblem(problem.id, true)).toEqual(
+      error("You do not have permission to like this problem"),
+    );
+    expect(await prisma.problemLike.count()).toBe(0);
+  });
+
+  it("rejects a SubmitOnly user, who cannot view the collection", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    await createPermission(user, collection, "SubmitOnly");
+    signInAs(user);
+
+    expect((await likeProblem(problem.id, true)).ok).toBe(false);
+  });
+
+  it("lets a ViewOnly user like, then unlike, a problem", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    await createPermission(user, collection, "ViewOnly");
+    signInAs(user);
+
+    expect(await likeProblem(problem.id, true)).toEqual({ ok: true });
+    expect(await prisma.problemLike.findMany()).toEqual([
+      { userId: user.id, problemId: problem.id },
+    ]);
+    expect(revalidateTag).toHaveBeenCalledWith(
+      `problem/${collection.cid}_${problem.pid}`,
+    );
+
+    expect(await likeProblem(problem.id, false)).toEqual({ ok: true });
+    expect(await prisma.problemLike.count()).toBe(0);
+  });
+
+  it("is idempotent when liking twice", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    await createPermission(user, collection);
+    signInAs(user);
+
+    expect(await likeProblem(problem.id, true)).toEqual({ ok: true });
+    expect(await likeProblem(problem.id, true)).toEqual({ ok: true });
+    expect(await prisma.problemLike.count()).toBe(1);
+  });
+
+  it("still succeeds when unliking a problem that was never liked", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    await createPermission(user, collection);
+    signInAs(user);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(await likeProblem(problem.id, false)).toEqual({ ok: true });
+    // The missing row is logged, not surfaced.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+});
+
+describe("editProblem", () => {
+  it("rejects a signed-out user on a normal collection", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection, { title: "Before" });
+    signOut();
+
+    expect(await editProblem(problem.id, { title: "After" })).toEqual(
+      error("Not signed in"),
+    );
+    const after = await prisma.problem.findUniqueOrThrow({
+      where: { id: problem.id },
+    });
+    expect(after.title).toBe("Before");
+  });
+
+  it("lets anyone, even signed out, edit problems in the demo collection", async () => {
+    // Intentional: see the `demo` gotcha in CLAUDE.md.
+    const collection = await createCollection({ cid: "demo" });
+    const problem = await createProblem(collection, { title: "Before" });
+    signOut();
+
+    expect(await editProblem(problem.id, { title: "After" })).toEqual({
+      ok: true,
+    });
+    const after = await prisma.problem.findUniqueOrThrow({
+      where: { id: problem.id },
+    });
+    expect(after.title).toBe("After");
+  });
+
+  it("rejects an unknown problem", async () => {
+    signInAs(await createUser());
+
+    expect(await editProblem(12345, { title: "x" })).toEqual(
+      error("No problem with id 12345"),
+    );
+  });
+
+  it("lets an Admin edit any problem and only touches the given fields", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection, {
+      title: "Old title",
+      statement: "Old statement",
+      answer: "Old answer",
+    });
+    const admin = await createUser();
+    await createPermission(admin, collection, "Admin");
+    signInAs(admin);
+
+    expect(
+      await editProblem(problem.id, { statement: "New statement" }),
+    ).toEqual({ ok: true });
+
+    const after = await prisma.problem.findUniqueOrThrow({
+      where: { id: problem.id },
+    });
+    expect(after).toMatchObject({
+      title: "Old title",
+      statement: "New statement",
+      answer: "Old answer",
+      isArchived: false,
+    });
+    expect(revalidateTag).toHaveBeenCalledWith(
+      `problem/${collection.cid}_${problem.pid}`,
+    );
+  });
+
+  it("lets a TeamMember edit only problems they authored", async () => {
+    const collection = await createCollection();
+    const member = await createUser();
+    await createPermission(member, collection, "TeamMember");
+    const memberAuthor = await createAuthor(collection, { userId: member.id });
+    const otherAuthor = await createAuthor(collection);
+    const own = await createProblem(collection, {
+      authorIds: [memberAuthor.id],
+    });
+    const theirs = await createProblem(collection, {
+      authorIds: [otherAuthor.id],
+    });
+    signInAs(member);
+
+    expect(await editProblem(own.id, { title: "Mine" })).toEqual({ ok: true });
+    expect(await editProblem(theirs.id, { title: "Not mine" })).toEqual(
+      error("You do not have permission to edit this problem"),
+    );
+  });
+
+  it("never lets a ViewOnly user edit, even their own problem", async () => {
+    const collection = await createCollection();
+    const viewer = await createUser();
+    await createPermission(viewer, collection, "ViewOnly");
+    const author = await createAuthor(collection, { userId: viewer.id });
+    const problem = await createProblem(collection, {
+      authorIds: [author.id],
+    });
+    signInAs(viewer);
+
+    expect((await editProblem(problem.id, { title: "x" })).ok).toBe(false);
+  });
+
+  it("can archive and unarchive", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const admin = await createUser();
+    await createPermission(admin, collection, "Admin");
+    signInAs(admin);
+
+    await editProblem(problem.id, { isArchived: true });
+    expect(
+      (await prisma.problem.findUniqueOrThrow({ where: { id: problem.id } }))
+        .isArchived,
+    ).toBe(true);
+
+    await editProblem(problem.id, { isArchived: false });
+    expect(
+      (await prisma.problem.findUniqueOrThrow({ where: { id: problem.id } }))
+        .isArchived,
+    ).toBe(false);
+  });
+});
+
+function commentForm(text?: string): FormData {
+  const form = new FormData();
+  if (text !== undefined) {
+    form.set("comment", text);
+  }
+  return form;
+}
+
+describe("addComment", () => {
+  it("rejects a form without a comment field", async () => {
+    signInAs(await createUser());
+
+    expect(await addComment(1, commentForm())).toEqual(error("Text is null"));
+  });
+
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await addComment(1, commentForm("hi"))).toEqual(
+      error("Not signed in"),
+    );
+  });
+
+  it("rejects an unknown problem", async () => {
+    signInAs(await createUser());
+
+    expect(await addComment(999, commentForm("hi"))).toEqual(
+      error("Problem not found"),
+    );
+  });
+
+  it("rejects a user without permission", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    signInAs(user);
+
+    expect(await addComment(problem.id, commentForm("hi"))).toEqual(
+      error("You do not have permission to comment on this problem"),
+    );
+    expect(await prisma.comment.count()).toBe(0);
+  });
+
+  it("lets any role, including ViewOnly and SubmitOnly, comment", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const viewer = await createUser();
+    await createPermission(viewer, collection, "ViewOnly");
+    const submitter = await createUser();
+    await createPermission(submitter, collection, "SubmitOnly");
+
+    signInAs(viewer);
+    expect(await addComment(problem.id, commentForm("first"))).toEqual({
+      ok: true,
+    });
+    signInAs(submitter);
+    expect(await addComment(problem.id, commentForm("second"))).toEqual({
+      ok: true,
+    });
+
+    const comments = await prisma.comment.findMany({ orderBy: { id: "asc" } });
+    expect(comments).toMatchObject([
+      { text: "first", userId: viewer.id, problemId: problem.id },
+      { text: "second", userId: submitter.id, problemId: problem.id },
+    ]);
+    expect(revalidateTag).toHaveBeenCalledWith(
+      `problem/${problem.id}/comments`,
+    );
+  });
+});
+
+describe("addSolution", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await addSolution(1, "text", 1)).toEqual(error("Not signed in"));
+  });
+
+  it("rejects an unknown problem", async () => {
+    signInAs(await createUser());
+
+    expect(await addSolution(999, "text", 1)).toEqual(
+      error("Problem not found"),
+    );
+  });
+
+  it.each(["ViewOnly", "SubmitOnly"] as const)(
+    "rejects a %s user",
+    async (level) => {
+      const collection = await createCollection();
+      const problem = await createProblem(collection);
+      const user = await createUser();
+      await createPermission(user, collection, level);
+      const author = await createAuthor(collection, { userId: user.id });
+      signInAs(user);
+
+      expect(await addSolution(problem.id, "text", author.id)).toEqual(
+        error("You do not have permission to edit this collection"),
+      );
+      expect(await prisma.solution.count()).toBe(0);
+    },
+  );
+
+  it("lets a TeamMember add a solution attributed to the given author", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const user = await createUser();
+    await createPermission(user, collection, "TeamMember");
+    const author = await createAuthor(collection, { userId: user.id });
+    signInAs(user);
+
+    expect(
+      await addSolution(problem.id, "Proof by intimidation", author.id),
+    ).toEqual({ ok: true });
+
+    const solutions = await prisma.solution.findMany({
+      include: { authors: true },
+    });
+    expect(solutions).toHaveLength(1);
+    expect(solutions[0]).toMatchObject({
+      problemId: problem.id,
+      text: "Proof by intimidation",
+    });
+    expect(solutions[0].authors.map((a) => a.id)).toEqual([author.id]);
+  });
+});
+
+describe("editSolution", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await editSolution(1, "text")).toEqual(error("Not signed in"));
+  });
+
+  it("rejects an unknown solution", async () => {
+    signInAs(await createUser());
+
+    expect((await editSolution(999, "text")).ok).toBe(false);
+  });
+
+  it("lets an Admin edit any solution", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const solution = await createSolution(problem, { text: "Before" });
+    const admin = await createUser();
+    await createPermission(admin, collection, "Admin");
+    signInAs(admin);
+
+    expect(await editSolution(solution.id, "After")).toEqual({ ok: true });
+    expect(
+      (
+        await prisma.solution.findUniqueOrThrow({
+          where: { id: solution.id },
+        })
+      ).text,
+    ).toBe("After");
+  });
+
+  it("lets a TeamMember edit only solutions they authored", async () => {
+    const collection = await createCollection();
+    const problem = await createProblem(collection);
+    const member = await createUser();
+    await createPermission(member, collection, "TeamMember");
+    const memberAuthor = await createAuthor(collection, { userId: member.id });
+    const otherAuthor = await createAuthor(collection);
+    const own = await createSolution(problem, {
+      authorIds: [memberAuthor.id],
+    });
+    const theirs = await createSolution(problem, {
+      authorIds: [otherAuthor.id],
+    });
+    signInAs(member);
+
+    expect(await editSolution(own.id, "edited")).toEqual({ ok: true });
+    expect(await editSolution(theirs.id, "edited")).toEqual(
+      error("You do not have permission to edit this collection"),
+    );
+  });
+});

--- a/test/integration/actions/testsolve.test.ts
+++ b/test/integration/actions/testsolve.test.ts
@@ -1,0 +1,269 @@
+import type { AccessLevel } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import {
+  giveUpTestsolve,
+  startTestsolve,
+  submitTestsolve,
+} from "@/app/c/[cid]/p/[pid]/actions";
+import prisma from "@/lib/prisma";
+import { error } from "@/lib/server-actions";
+import {
+  createCollection,
+  createPermission,
+  createProblem,
+  createUser,
+} from "../factories";
+import { signInAs, signOut } from "../session";
+
+// Mirrors the constants in app/c/[cid]/p/[pid]/actions.ts.
+const SUBMISSION_LIMIT = 5;
+const BUFFER_MILLIS = 10_000;
+const MINUTE = 60_000;
+const SECOND = 1_000;
+function timeLimitMillis(difficulty: number): number {
+  return (difficulty * 5 + 5) * MINUTE;
+}
+
+async function setup({
+  accessLevel = "TeamMember",
+  difficulty = 1 as number | null,
+  answer = "42",
+} = {}) {
+  const collection = await createCollection({ requireTestsolve: true });
+  const problem = await createProblem(collection, { difficulty, answer });
+  const user = await createUser();
+  await createPermission(user, collection, accessLevel as AccessLevel);
+  signInAs(user);
+  return { collection, problem, user };
+}
+
+/** Rewind an attempt's start time so it began `millisAgo` milliseconds ago. */
+async function startedAgo(
+  user: { id: string },
+  problem: { id: number },
+  millisAgo: number,
+) {
+  await prisma.solveAttempt.update({
+    where: { userId_problemId: { userId: user.id, problemId: problem.id } },
+    data: { startedAt: new Date(Date.now() - millisAgo) },
+  });
+}
+
+async function attempt(user: { id: string }, problem: { id: number }) {
+  return prisma.solveAttempt.findUniqueOrThrow({
+    where: { userId_problemId: { userId: user.id, problemId: problem.id } },
+  });
+}
+
+describe("startTestsolve", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await startTestsolve(1)).toEqual(error("Not signed in"));
+  });
+
+  it("rejects an unknown problem", async () => {
+    signInAs(await createUser());
+
+    expect(await startTestsolve(999)).toEqual(error("Problem not found"));
+  });
+
+  it("rejects a user who cannot view the collection", async () => {
+    const { problem } = await setup({ accessLevel: "SubmitOnly" });
+
+    expect((await startTestsolve(problem.id)).ok).toBe(false);
+    expect(await prisma.solveAttempt.count()).toBe(0);
+  });
+
+  it("records a fresh attempt", async () => {
+    const { problem, user } = await setup();
+    const before = Date.now();
+
+    expect(await startTestsolve(problem.id)).toEqual({ ok: true });
+
+    const row = await attempt(user, problem);
+    expect(row).toMatchObject({
+      numSubmissions: 0,
+      solvedAt: null,
+      gaveUp: false,
+    });
+    expect(row.startedAt.getTime()).toBeGreaterThanOrEqual(before - SECOND);
+  });
+
+  it("cannot be started twice for the same user and problem", async () => {
+    const { problem, user } = await setup();
+    await startTestsolve(problem.id);
+    await startedAgo(user, problem, 5 * MINUTE);
+
+    expect((await startTestsolve(problem.id)).ok).toBe(false);
+    // The original attempt (and its start time) is untouched.
+    const row = await attempt(user, problem);
+    expect(Date.now() - row.startedAt.getTime()).toBeGreaterThan(4 * MINUTE);
+  });
+});
+
+describe("submitTestsolve", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await submitTestsolve(1, "42")).toEqual(error("Not signed in"));
+  });
+
+  it("rejects a submission before the testsolve was started", async () => {
+    const { problem } = await setup();
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual(
+      error("Tried to submit before starting testsolve"),
+    );
+  });
+
+  it("rejects a problem with no difficulty, which has no time limit", async () => {
+    const { problem } = await setup({ difficulty: null });
+    await startTestsolve(problem.id);
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual(
+      error("Problem difficulty should not be null"),
+    );
+  });
+
+  it("marks a correct answer as solved and reports remaining tries", async () => {
+    const { problem, user } = await setup({ answer: "42" });
+    await startTestsolve(problem.id);
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual({
+      ok: true,
+      data: { correct: true, remaining: SUBMISSION_LIMIT - 1 },
+    });
+
+    const row = await attempt(user, problem);
+    expect(row.numSubmissions).toBe(1);
+    expect(row.solvedAt).not.toBeNull();
+  });
+
+  it("counts a wrong answer without marking it solved", async () => {
+    const { problem, user } = await setup({ answer: "42" });
+    await startTestsolve(problem.id);
+
+    expect(await submitTestsolve(problem.id, "41")).toEqual({
+      ok: true,
+      data: { correct: false, remaining: SUBMISSION_LIMIT - 1 },
+    });
+
+    const row = await attempt(user, problem);
+    expect(row.numSubmissions).toBe(1);
+    expect(row.solvedAt).toBeNull();
+  });
+
+  it("compares answers as exact strings", async () => {
+    const { problem } = await setup({ answer: "42" });
+    await startTestsolve(problem.id);
+
+    const resp = await submitTestsolve(problem.id, " 42");
+    expect(resp.ok && resp.data.correct).toBe(false);
+  });
+
+  it(`allows exactly ${SUBMISSION_LIMIT} submissions`, async () => {
+    const { problem } = await setup({ answer: "42" });
+    await startTestsolve(problem.id);
+
+    for (let i = 1; i <= SUBMISSION_LIMIT; i++) {
+      expect(await submitTestsolve(problem.id, "wrong")).toEqual({
+        ok: true,
+        data: { correct: false, remaining: SUBMISSION_LIMIT - i },
+      });
+    }
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual(
+      error(`Reached maximum number of submissions (${SUBMISSION_LIMIT})`),
+    );
+  });
+
+  it("accepts a submission inside the grace buffer after the time limit", async () => {
+    const { problem, user } = await setup({ difficulty: 1 });
+    await startTestsolve(problem.id);
+    await startedAgo(user, problem, timeLimitMillis(1) + BUFFER_MILLIS / 2);
+
+    expect((await submitTestsolve(problem.id, "42")).ok).toBe(true);
+  });
+
+  it("rejects a submission once the buffer has also elapsed", async () => {
+    const { problem, user } = await setup({ difficulty: 1 });
+    await startTestsolve(problem.id);
+    await startedAgo(
+      user,
+      problem,
+      timeLimitMillis(1) + BUFFER_MILLIS + SECOND,
+    );
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual(
+      error("Tried to submit after testsolve finished"),
+    );
+    expect((await attempt(user, problem)).numSubmissions).toBe(0);
+  });
+
+  it("gives harder problems more time (difficulty * 5 + 5 minutes)", async () => {
+    const { problem, user } = await setup({ difficulty: 5 });
+    await startTestsolve(problem.id);
+
+    // 30-minute limit: 25 minutes in is fine, 31 is not.
+    await startedAgo(user, problem, 25 * MINUTE);
+    expect((await submitTestsolve(problem.id, "wrong")).ok).toBe(true);
+
+    await startedAgo(user, problem, 31 * MINUTE);
+    expect((await submitTestsolve(problem.id, "42")).ok).toBe(false);
+  });
+
+  it("rejects a submission after giving up", async () => {
+    const { problem } = await setup();
+    await startTestsolve(problem.id);
+    await giveUpTestsolve(problem.id);
+
+    expect(await submitTestsolve(problem.id, "42")).toEqual(
+      error("Tried to submit after testsolve finished"),
+    );
+  });
+});
+
+describe("giveUpTestsolve", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await giveUpTestsolve(1)).toEqual(error("Not signed in"));
+  });
+
+  it("rejects giving up before starting", async () => {
+    const { problem } = await setup();
+
+    expect(await giveUpTestsolve(problem.id)).toEqual(
+      error("Tried to submit before starting testsolve"),
+    );
+  });
+
+  it("marks the attempt as given up", async () => {
+    const { problem, user } = await setup();
+    await startTestsolve(problem.id);
+
+    expect(await giveUpTestsolve(problem.id)).toEqual({ ok: true });
+    expect((await attempt(user, problem)).gaveUp).toBe(true);
+  });
+
+  it("cannot give up twice", async () => {
+    const { problem } = await setup();
+    await startTestsolve(problem.id);
+    await giveUpTestsolve(problem.id);
+
+    expect(await giveUpTestsolve(problem.id)).toEqual(
+      error("Tried to submit after testsolve finished"),
+    );
+  });
+
+  it("has no grace buffer, unlike submitting", async () => {
+    const { problem, user } = await setup({ difficulty: 1 });
+    await startTestsolve(problem.id);
+    await startedAgo(user, problem, timeLimitMillis(1) + BUFFER_MILLIS / 2);
+
+    expect(await giveUpTestsolve(problem.id)).toEqual(
+      error("Tried to submit after testsolve finished"),
+    );
+  });
+});

--- a/test/integration/actions/testsolver-type.test.ts
+++ b/test/integration/actions/testsolver-type.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { setTestsolverType } from "@/app/c/[cid]/choose-testsolver-type/actions";
+import prisma from "@/lib/prisma";
+import { error } from "@/lib/server-actions";
+import { createCollection, createPermission, createUser } from "../factories";
+import { expectNotFound, expectRedirect } from "../navigation";
+import { signInAs, signOut } from "../session";
+
+describe("setTestsolverType", () => {
+  it("rejects a signed-out user", async () => {
+    signOut();
+
+    expect(await setTestsolverType(1, "Casual")).toEqual(
+      error("Not signed in"),
+    );
+  });
+
+  it("404s for an unknown collection", async () => {
+    signInAs(await createUser());
+
+    await expectNotFound(setTestsolverType(999, "Casual"));
+  });
+
+  it("rejects a user with no permission on the collection", async () => {
+    const collection = await createCollection({ requireTestsolve: true });
+    signInAs(await createUser());
+
+    expect(await setTestsolverType(collection.id, "Casual")).toEqual(
+      error("You do not have access to this collection"),
+    );
+  });
+
+  it.each(["Casual", "Serious"] as const)(
+    "records the %s choice, dated from the collection's creation, and redirects",
+    async (type) => {
+      const collection = await createCollection({ requireTestsolve: true });
+      const user = await createUser();
+      await createPermission(user, collection, "TeamMember");
+      signInAs(user);
+
+      await expectRedirect(
+        setTestsolverType(collection.id, type),
+        `/c/${collection.cid}`,
+      );
+
+      const permission = await prisma.permission.findUniqueOrThrow({
+        where: {
+          userId_collectionId: { userId: user.id, collectionId: collection.id },
+        },
+      });
+      expect(permission).toMatchObject({
+        accessLevel: "TeamMember",
+        testsolverType: type,
+        seriousTestsolverStartedAt: collection.createdAt,
+      });
+    },
+  );
+
+  it("only changes the calling user's permission", async () => {
+    const collection = await createCollection({ requireTestsolve: true });
+    const user = await createUser();
+    const other = await createUser();
+    await createPermission(user, collection);
+    await createPermission(other, collection);
+    signInAs(user);
+
+    await expectRedirect(
+      setTestsolverType(collection.id, "Serious"),
+      `/c/${collection.cid}`,
+    );
+
+    const otherPermission = await prisma.permission.findUniqueOrThrow({
+      where: {
+        userId_collectionId: { userId: other.id, collectionId: collection.id },
+      },
+    });
+    expect(otherPermission.testsolverType).toBeNull();
+  });
+});

--- a/test/integration/api/collection-problems.test.ts
+++ b/test/integration/api/collection-problems.test.ts
@@ -1,0 +1,162 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/collections/[cid]/problems/route";
+import {
+  createApiToken,
+  createAuthor,
+  createCollection,
+  createProblem,
+  createSolution,
+  createUser,
+} from "../factories";
+
+async function get(cid: string, headers: Record<string, string> = {}) {
+  const request = new NextRequest(
+    `http://localhost/api/collections/${cid}/problems`,
+    { headers },
+  );
+  const response = await GET(request, { params: Promise.resolve({ cid }) });
+  return { status: response.status, body: (await response.json()) as unknown };
+}
+
+describe("GET /api/collections/[cid]/problems", () => {
+  it("401s without an Authorization header", async () => {
+    const { status, body } = await get("anything");
+
+    expect(status).toBe(401);
+    expect(body).toEqual({
+      error: "Missing or invalid Authorization header. Use: Bearer <token>",
+    });
+  });
+
+  it("401s for a non-Bearer scheme", async () => {
+    const { status } = await get("anything", { Authorization: "Basic abc" });
+
+    expect(status).toBe(401);
+  });
+
+  it("401s for a Bearer header with no token", async () => {
+    // Header values are whitespace-trimmed, so "Bearer " arrives as "Bearer".
+    const { status } = await get("anything", { Authorization: "Bearer " });
+
+    expect(status).toBe(401);
+  });
+
+  it("401s for an unknown token", async () => {
+    const { status, body } = await get("anything", {
+      Authorization: "Bearer not-a-real-token",
+    });
+
+    expect(status).toBe(401);
+    expect(body).toEqual({ error: "Invalid API token" });
+  });
+
+  it("403s when the token belongs to a different collection", async () => {
+    const owner = await createUser();
+    const mine = await createCollection();
+    const theirs = await createCollection();
+    const token = await createApiToken(mine, owner);
+
+    const { status, body } = await get(theirs.cid, {
+      Authorization: `Bearer ${token.token}`,
+    });
+
+    expect(status).toBe(403);
+    expect(body).toEqual({ error: "Token not authorized for this collection" });
+  });
+
+  it("returns an empty list for a collection with no problems", async () => {
+    const owner = await createUser();
+    const collection = await createCollection({ name: "Empty" });
+    const token = await createApiToken(collection, owner);
+
+    const { status, body } = await get(collection.cid, {
+      Authorization: `Bearer ${token.token}`,
+    });
+
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      collection: { cid: collection.cid, name: "Empty" },
+      problems: [],
+    });
+  });
+
+  it("returns non-archived problems, newest first, with authors and solutions", async () => {
+    const owner = await createUser();
+    const collection = await createCollection();
+    const token = await createApiToken(collection, owner);
+    const author = await createAuthor(collection, {
+      displayName: "Euler",
+      country: "CH",
+    });
+
+    const older = await createProblem(collection, {
+      pid: "A1",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      authorIds: [author.id],
+      source: "Basel",
+    });
+    await createSolution(older, {
+      text: "Sum the series.",
+      summary: "Series",
+      authorIds: [author.id],
+    });
+    const newer = await createProblem(collection, {
+      pid: "A2",
+      createdAt: new Date("2024-06-01T00:00:00Z"),
+    });
+    await createProblem(collection, {
+      pid: "A3",
+      createdAt: new Date("2024-12-01T00:00:00Z"),
+      isArchived: true,
+    });
+    // A problem in another collection must not leak through.
+    await createProblem(await createCollection(), { pid: "A1" });
+
+    const { status, body } = await get(collection.cid, {
+      Authorization: `Bearer ${token.token}`,
+    });
+
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      collection: { cid: collection.cid, name: collection.name },
+      problems: [
+        {
+          id: newer.id,
+          pid: "A2",
+          title: newer.title,
+          statement: newer.statement,
+          answer: "42",
+          subject: "Algebra",
+          difficulty: 1,
+          source: null,
+          isArchived: false,
+          createdAt: "2024-06-01T00:00:00.000Z",
+          authors: [],
+          solutions: [],
+        },
+        {
+          id: older.id,
+          pid: "A1",
+          title: older.title,
+          statement: older.statement,
+          answer: "42",
+          subject: "Algebra",
+          difficulty: 1,
+          source: "Basel",
+          isArchived: false,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          authors: [{ id: author.id, displayName: "Euler", country: "CH" }],
+          solutions: [
+            {
+              id: expect.any(Number) as number,
+              text: "Sum the series.",
+              summary: "Series",
+              authors: [{ id: author.id, displayName: "Euler" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/test/integration/factories.ts
+++ b/test/integration/factories.ts
@@ -1,0 +1,147 @@
+import type { AccessLevel, Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
+
+// Minimal row builders. Every required column gets a sane default; pass overrides for the rest.
+// A counter keeps unique columns (email, cid, pid, invite code, token) distinct within a test.
+
+let counter = 0;
+function next(): number {
+  counter += 1;
+  return counter;
+}
+
+export function createUser(overrides: Partial<Prisma.UserCreateInput> = {}) {
+  const n = next();
+  return prisma.user.create({
+    data: {
+      id: `user-${n}`,
+      name: `User ${n}`,
+      email: `user${n}@example.com`,
+      ...overrides,
+    },
+  });
+}
+
+export function createCollection(
+  overrides: Partial<Prisma.CollectionCreateInput> = {},
+) {
+  const n = next();
+  return prisma.collection.create({
+    data: {
+      name: `Collection ${n}`,
+      cid: `collection-${n}`,
+      showAuthors: true,
+      ...overrides,
+    },
+  });
+}
+
+export function createPermission(
+  user: { id: string },
+  collection: { id: number },
+  accessLevel: AccessLevel = "TeamMember",
+  overrides: Partial<Prisma.PermissionUncheckedCreateInput> = {},
+) {
+  return prisma.permission.create({
+    data: {
+      userId: user.id,
+      collectionId: collection.id,
+      accessLevel,
+      ...overrides,
+    },
+  });
+}
+
+export function createAuthor(
+  collection: { id: number },
+  overrides: Partial<Prisma.AuthorUncheckedCreateInput> = {},
+) {
+  const n = next();
+  return prisma.author.create({
+    data: {
+      displayName: `Author ${n}`,
+      collectionId: collection.id,
+      ...overrides,
+    },
+  });
+}
+
+export function createProblem(
+  collection: { id: number },
+  overrides: Partial<Prisma.ProblemUncheckedCreateInput> & {
+    authorIds?: number[];
+  } = {},
+) {
+  const n = next();
+  const { authorIds, ...rest } = overrides;
+  return prisma.problem.create({
+    data: {
+      collectionId: collection.id,
+      pid: `A${n}`,
+      title: `Problem ${n}`,
+      statement: `Statement ${n}`,
+      subject: "Algebra",
+      answer: "42",
+      difficulty: 1,
+      isAnonymous: false,
+      ...(authorIds && {
+        authors: { connect: authorIds.map((id) => ({ id })) },
+      }),
+      ...rest,
+    },
+  });
+}
+
+export function createSolution(
+  problem: { id: number },
+  overrides: Partial<Prisma.SolutionUncheckedCreateInput> & {
+    authorIds?: number[];
+  } = {},
+) {
+  const n = next();
+  const { authorIds, ...rest } = overrides;
+  return prisma.solution.create({
+    data: {
+      problemId: problem.id,
+      text: `Solution ${n}`,
+      ...(authorIds && {
+        authors: { connect: authorIds.map((id) => ({ id })) },
+      }),
+      ...rest,
+    },
+  });
+}
+
+export function createInvite(
+  collection: { id: number },
+  inviter: { id: string },
+  overrides: Partial<Prisma.InviteUncheckedCreateInput> = {},
+) {
+  const n = next();
+  return prisma.invite.create({
+    data: {
+      collectionId: collection.id,
+      inviterId: inviter.id,
+      accessLevel: "TeamMember",
+      code: `invite-${n}`,
+      ...overrides,
+    },
+  });
+}
+
+export function createApiToken(
+  collection: { id: number },
+  createdBy: { id: string },
+  overrides: Partial<Prisma.ApiTokenUncheckedCreateInput> = {},
+) {
+  const n = next();
+  return prisma.apiToken.create({
+    data: {
+      collectionId: collection.id,
+      createdByUserId: createdBy.id,
+      token: `token-${n}`,
+      name: `Token ${n}`,
+      ...overrides,
+    },
+  });
+}

--- a/test/integration/global-setup.ts
+++ b/test/integration/global-setup.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+// Runs once, in the main process, before any integration test file.
+// Applies the Prisma migrations so the test database matches prisma/schema.prisma.
+export default function setup() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is not set. Run integration tests with `npm run test:integration` " +
+        "(it loads .env.test) and start the database with `npm run test:db`.",
+    );
+  }
+
+  // The tests TRUNCATE every table before each test. Never let that hit a real database.
+  const dbName = new URL(url).pathname.replace(/^\//, "");
+  if (!dbName.endsWith("_test")) {
+    throw new Error(
+      `Refusing to run integration tests against database "${dbName}": ` +
+        "the name must end with `_test` (see .env.test).",
+    );
+  }
+
+  const require = createRequire(import.meta.url);
+  const prismaCli = require.resolve("prisma/build/index.js");
+  try {
+    execFileSync(process.execPath, [prismaCli, "migrate", "deploy"], {
+      stdio: "pipe",
+      env: process.env,
+    });
+  } catch (err) {
+    const stderr =
+      err instanceof Error && "stderr" in err
+        ? String((err as { stderr: unknown }).stderr)
+        : String(err);
+    throw new Error(
+      "`prisma migrate deploy` failed against the test database. " +
+        "Is it running? Start it with `npm run test:db`.\n\n" +
+        stderr,
+    );
+  }
+}

--- a/test/integration/navigation.ts
+++ b/test/integration/navigation.ts
@@ -1,0 +1,37 @@
+import { isNotFoundError } from "next/dist/client/components/not-found";
+import {
+  getURLFromRedirectError,
+  isRedirectError,
+} from "next/dist/client/components/redirect";
+import { expect } from "vitest";
+
+// `redirect()` and `notFound()` work by throwing. These helpers assert on that throw.
+
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    (value) => {
+      throw new Error(
+        `Expected the action to throw, but it resolved with ${JSON.stringify(value)}`,
+      );
+    },
+    (err: unknown) => err,
+  );
+}
+
+export async function expectRedirect(
+  promise: Promise<unknown>,
+  path: string,
+): Promise<void> {
+  const err = await rejection(promise);
+  if (!isRedirectError(err)) {
+    throw err;
+  }
+  expect(getURLFromRedirectError(err)).toBe(path);
+}
+
+export async function expectNotFound(promise: Promise<unknown>): Promise<void> {
+  const err = await rejection(promise);
+  if (!isNotFoundError(err)) {
+    throw err;
+  }
+}

--- a/test/integration/session.ts
+++ b/test/integration/session.ts
@@ -1,0 +1,30 @@
+import type { Session } from "next-auth";
+import type { Mock } from "vitest";
+import { auth } from "auth";
+
+// `auth` is mocked in ./setup.ts; this is the handle the tests use to control it.
+const mockedAuth = auth as unknown as Mock<() => Promise<Session | null>>;
+
+/**
+ * Make `auth()` resolve to a session for the given user, or to `null` when signed out.
+ * Only the fields the app reads (`userId`, `currentEmail`) are populated.
+ */
+export function signInAs(
+  user: { id: string; email?: string | null } | null,
+): void {
+  if (user === null) {
+    mockedAuth.mockResolvedValue(null);
+    return;
+  }
+  const session = {
+    expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    userId: user.id,
+    currentEmail: user.email ?? null,
+    emailVerified: true,
+  } as Session;
+  mockedAuth.mockResolvedValue(session);
+}
+
+export function signOut(): void {
+  signInAs(null);
+}

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -1,0 +1,37 @@
+import { afterAll, beforeEach, vi } from "vitest";
+import prisma from "@/lib/prisma";
+
+// Runs in the worker before each integration test file.
+
+// `auth()` would boot NextAuth with the Google provider and the Prisma adapter.
+// Replace it with a mock the tests control through `signInAs()` (see ./session.ts).
+vi.mock("auth", () => ({ auth: vi.fn() }));
+
+// Server actions call revalidateTag(), which needs a Next.js request context.
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+async function resetDatabase() {
+  const tables = await prisma.$queryRaw<{ tablename: string }[]>`
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND tablename <> '_prisma_migrations'
+  `;
+  if (tables.length === 0) {
+    return;
+  }
+  const list = tables.map((t) => `"${t.tablename}"`).join(", ");
+  await prisma.$executeRawUnsafe(
+    `TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE`,
+  );
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});

--- a/test/setup-dom.ts
+++ b/test/setup-dom.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Testing Library only auto-cleans when `afterEach` is a global; we don't enable Vitest globals.
+afterEach(() => {
+  cleanup();
+});

--- a/test/unit/components/aime-input.test.tsx
+++ b/test/unit/components/aime-input.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import AimeInput from "@/components/aime-input";
+
+// AimeInput is a controlled component; this harness gives it real state so typing works end to end.
+function Harness({ initial = "" }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return <AimeInput value={value} onValueChange={setValue} required={false} />;
+}
+
+describe("AimeInput", () => {
+  it("accepts digits and strips leading zeros as the user types", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    await user.type(input, "007");
+
+    expect(input).toHaveValue("7");
+  });
+
+  it("caps the value at three digits", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    await user.type(input, "1234");
+
+    expect(input).toHaveValue("123");
+  });
+
+  it("ignores non-digit characters", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    await user.type(input, "a-1.5");
+
+    expect(input).toHaveValue("15");
+  });
+
+  it("allows clearing the field", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial="42" />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    await user.clear(input);
+
+    expect(input).toHaveValue("");
+  });
+
+  it("does not report invalid pasted values", () => {
+    const onValueChange = vi.fn();
+    render(<AimeInput value="" onValueChange={onValueChange} required />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    fireEvent.change(input, { target: { value: "1000" } });
+    fireEvent.change(input, { target: { value: "-5" } });
+    fireEvent.change(input, { target: { value: "12a" } });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("normalizes valid pasted values", () => {
+    const onValueChange = vi.fn();
+    render(<AimeInput value="" onValueChange={onValueChange} required />);
+    const input = screen.getByPlaceholderText("Enter a number (0-999)");
+
+    fireEvent.change(input, { target: { value: "099" } });
+
+    expect(onValueChange).toHaveBeenCalledWith("99");
+  });
+
+  it("submits under the field name 'answer'", () => {
+    render(<AimeInput value="" onValueChange={() => {}} required />);
+    expect(
+      screen.getByPlaceholderText("Enter a number (0-999)"),
+    ).toHaveAttribute("name", "answer");
+  });
+});

--- a/test/unit/components/integer-input.test.tsx
+++ b/test/unit/components/integer-input.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import IntegerInput from "@/components/integer-input";
+
+function Harness({ initial = "" }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <IntegerInput value={value} onValueChange={setValue} required={false} />
+  );
+}
+
+describe("IntegerInput", () => {
+  it("accepts negative integers typed one character at a time", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    await user.type(input, "-17");
+
+    expect(input).toHaveValue("-17");
+  });
+
+  it("keeps a lone minus sign while the user is still typing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    await user.type(input, "-");
+
+    expect(input).toHaveValue("-");
+  });
+
+  it("strips leading zeros", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    await user.type(input, "0042");
+
+    expect(input).toHaveValue("42");
+  });
+
+  it("ignores decimals, letters, and a second minus sign", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    await user.type(input, "-1.5e3-");
+
+    expect(input).toHaveValue("-153");
+  });
+
+  it("has no length limit, unlike AimeInput", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    await user.type(input, "123456");
+
+    expect(input).toHaveValue("123456");
+  });
+
+  it("does not report invalid pasted values", () => {
+    const onValueChange = vi.fn();
+    render(<IntegerInput value="" onValueChange={onValueChange} required />);
+    const input = screen.getByPlaceholderText("Enter an integer");
+
+    fireEvent.change(input, { target: { value: "1.5" } });
+    fireEvent.change(input, { target: { value: "abc" } });
+    fireEvent.change(input, { target: { value: "--1" } });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("submits under the field name 'answer'", () => {
+    render(<IntegerInput value="" onValueChange={() => {}} required />);
+    expect(screen.getByPlaceholderText("Enter an integer")).toHaveAttribute(
+      "name",
+      "answer",
+    );
+  });
+});

--- a/test/unit/lib/filter.test.ts
+++ b/test/unit/lib/filter.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { type Filter, filterToString, parseFilter } from "@/lib/filter";
+
+const emptyFilter: Filter = {
+  subjects: [],
+  search: "",
+  archived: false,
+  page: 1,
+  unsolvedOnly: false,
+};
+
+describe("parseFilter", () => {
+  it("returns the default filter for empty search params", () => {
+    expect(parseFilter({})).toEqual(emptyFilter);
+  });
+
+  it("maps subject initials to subjects, in canonical order", () => {
+    expect(parseFilter({ subject: "gca" }).subjects).toEqual([
+      "Algebra",
+      "Combinatorics",
+      "Geometry",
+    ]);
+    expect(parseFilter({ subject: "n" }).subjects).toEqual(["NumberTheory"]);
+  });
+
+  it("accepts upper-case subject initials and ignores unknown letters", () => {
+    expect(parseFilter({ subject: "XAz" }).subjects).toEqual(["Algebra"]);
+  });
+
+  it("only treats the literal string 'true' as a boolean flag", () => {
+    expect(parseFilter({ archived: "true" }).archived).toBe(true);
+    expect(parseFilter({ archived: "1" }).archived).toBe(false);
+    expect(parseFilter({ archived: "TRUE" }).archived).toBe(false);
+    expect(parseFilter({ unsolvedOnly: "true" }).unsolvedOnly).toBe(true);
+    expect(parseFilter({ unsolvedOnly: "false" }).unsolvedOnly).toBe(false);
+  });
+
+  it("parses the page number", () => {
+    expect(parseFilter({ page: "3" }).page).toBe(3);
+    expect(parseFilter({ page: "07" }).page).toBe(7);
+  });
+
+  it("passes the search string through untouched", () => {
+    expect(parseFilter({ search: "  Hello World " }).search).toBe(
+      "  Hello World ",
+    );
+  });
+
+  it("ignores repeated (array-valued) params", () => {
+    expect(
+      parseFilter({
+        subject: ["a", "c"],
+        search: ["x"],
+        page: ["2"],
+        archived: ["true"],
+      }),
+    ).toEqual(emptyFilter);
+  });
+});
+
+describe("filterToString", () => {
+  it("returns an empty string for the default filter", () => {
+    expect(filterToString(emptyFilter)).toBe("");
+  });
+
+  it("omits page 1 but keeps other pages", () => {
+    expect(filterToString({ ...emptyFilter, page: 1 })).toBe("");
+    expect(filterToString({ ...emptyFilter, page: 2 })).toBe("?page=2");
+  });
+
+  it("encodes subjects as their lower-case initials", () => {
+    expect(
+      filterToString({
+        ...emptyFilter,
+        subjects: ["Combinatorics", "NumberTheory"],
+      }),
+    ).toBe("?subject=cn");
+  });
+
+  it("URL-encodes the search string", () => {
+    expect(filterToString({ ...emptyFilter, search: "a & b" })).toBe(
+      "?search=a+%26+b",
+    );
+  });
+
+  it("includes every non-default field", () => {
+    expect(
+      filterToString({
+        subjects: ["Algebra"],
+        search: "roots",
+        archived: true,
+        page: 4,
+        unsolvedOnly: true,
+      }),
+    ).toBe("?subject=a&search=roots&archived=true&page=4&unsolvedOnly=true");
+  });
+});
+
+describe("round trip", () => {
+  const cases: Filter[] = [
+    emptyFilter,
+    { ...emptyFilter, page: 12 },
+    { ...emptyFilter, subjects: ["Algebra", "Geometry"] },
+    { ...emptyFilter, search: "x^2 + y^2 = z^2" },
+    { ...emptyFilter, archived: true, unsolvedOnly: true },
+    {
+      subjects: ["Algebra", "Combinatorics", "Geometry", "NumberTheory"],
+      search: "wall of text",
+      archived: true,
+      page: 3,
+      unsolvedOnly: true,
+    },
+  ];
+
+  it.each(cases)(
+    "parseFilter(filterToString(%o)) is the identity",
+    (filter) => {
+      const query = filterToString(filter);
+      const params = Object.fromEntries(new URLSearchParams(query));
+      expect(parseFilter(params)).toEqual(filter);
+    },
+  );
+});

--- a/test/unit/lib/permissions.test.ts
+++ b/test/unit/lib/permissions.test.ts
@@ -1,0 +1,130 @@
+import type { AccessLevel } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import {
+  canAddComment,
+  canAddProblem,
+  canAddSolution,
+  canEditProblem,
+  canEditSolution,
+  canViewCollection,
+  isAdmin,
+} from "@/lib/permissions";
+
+const allLevels: AccessLevel[] = [
+  "Admin",
+  "TeamMember",
+  "ViewOnly",
+  "SubmitOnly",
+];
+
+function perm(accessLevel: AccessLevel) {
+  return { accessLevel };
+}
+
+// One row per access level, so a change to any role's rights shows up as a diff here.
+describe("role-only checks", () => {
+  const table: {
+    name: string;
+    fn: (p: { accessLevel: AccessLevel } | null) => boolean;
+    allowed: AccessLevel[];
+  }[] = [
+    { name: "isAdmin", fn: isAdmin, allowed: ["Admin"] },
+    {
+      name: "canAddProblem",
+      fn: canAddProblem,
+      allowed: ["Admin", "TeamMember", "SubmitOnly"],
+    },
+    {
+      name: "canAddSolution",
+      fn: canAddSolution,
+      allowed: ["Admin", "TeamMember"],
+    },
+    {
+      name: "canAddComment",
+      fn: canAddComment,
+      allowed: ["Admin", "TeamMember", "SubmitOnly", "ViewOnly"],
+    },
+    {
+      name: "canViewCollection",
+      fn: canViewCollection,
+      allowed: ["Admin", "TeamMember", "ViewOnly"],
+    },
+  ];
+
+  describe.each(table)("$name", ({ fn, allowed }) => {
+    it("denies when there is no permission row", () => {
+      expect(fn(null)).toBe(false);
+    });
+
+    it.each(allLevels)("%s", (level) => {
+      expect(fn(perm(level))).toBe(allowed.includes(level));
+    });
+  });
+});
+
+describe("canEditProblem", () => {
+  const problem = { authors: [{ id: 1 }, { id: 2 }] };
+  const matchingAuthors = [{ id: 2 }];
+  const otherAuthors = [{ id: 3 }];
+
+  it("denies when there is no permission row, even for an author", () => {
+    expect(canEditProblem(problem, null, matchingAuthors)).toBe(false);
+  });
+
+  it("lets an Admin edit any problem", () => {
+    expect(canEditProblem(problem, perm("Admin"), otherAuthors)).toBe(true);
+    expect(canEditProblem(problem, perm("Admin"), [])).toBe(true);
+  });
+
+  it.each<AccessLevel>(["TeamMember", "SubmitOnly"])(
+    "lets a %s edit only problems they authored",
+    (level) => {
+      expect(canEditProblem(problem, perm(level), matchingAuthors)).toBe(true);
+      expect(canEditProblem(problem, perm(level), otherAuthors)).toBe(false);
+      expect(canEditProblem(problem, perm(level), [])).toBe(false);
+    },
+  );
+
+  it("never lets a ViewOnly user edit, even their own problem", () => {
+    expect(canEditProblem(problem, perm("ViewOnly"), matchingAuthors)).toBe(
+      false,
+    );
+  });
+
+  it("denies when the problem has no authors", () => {
+    const orphan = { authors: [] };
+    expect(canEditProblem(orphan, perm("TeamMember"), matchingAuthors)).toBe(
+      false,
+    );
+  });
+});
+
+describe("canEditSolution", () => {
+  const solution = { authors: [{ id: 7 }] };
+  const matchingAuthors = [{ id: 7 }, { id: 8 }];
+  const otherAuthors = [{ id: 9 }];
+
+  it("denies when there is no permission row", () => {
+    expect(canEditSolution(solution, null, matchingAuthors)).toBe(false);
+  });
+
+  it("lets an Admin edit any solution", () => {
+    expect(canEditSolution(solution, perm("Admin"), otherAuthors)).toBe(true);
+  });
+
+  it.each<AccessLevel>(["TeamMember", "SubmitOnly"])(
+    "lets a %s edit only solutions they authored",
+    (level) => {
+      expect(canEditSolution(solution, perm(level), matchingAuthors)).toBe(
+        true,
+      );
+      expect(canEditSolution(solution, perm(level), otherAuthors)).toBe(false);
+    },
+  );
+
+  it("never lets a ViewOnly user edit", () => {
+    expect(canEditSolution(solution, perm("ViewOnly"), matchingAuthors)).toBe(
+      false,
+    );
+  });
+});

--- a/test/unit/lib/server-actions.test.ts
+++ b/test/unit/lib/server-actions.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ActionResponse,
+  type ActionResponseOk,
+  error,
+  wrapAction,
+} from "@/lib/server-actions";
+
+describe("error", () => {
+  it("builds a failed ActionResponse carrying the message", () => {
+    expect(error("nope")).toEqual({ ok: false, error: { message: "nope" } });
+  });
+});
+
+describe("wrapAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Let the fire-and-forget promise inside wrapAction settle.
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("returns a synchronous function that forwards its arguments", async () => {
+    const action = vi
+      .fn<(a: number, b: string) => Promise<ActionResponse>>()
+      .mockResolvedValue({ ok: true });
+    const wrapped = wrapAction(action);
+
+    const result = wrapped(1, "two") as unknown;
+    await flush();
+
+    expect(result).toBeUndefined();
+    expect(action).toHaveBeenCalledWith(1, "two");
+  });
+
+  it("calls onSuccess with the successful response", async () => {
+    const action = (): Promise<ActionResponse<{ n: number }>> =>
+      Promise.resolve({ ok: true, data: { n: 7 } });
+    const onSuccess = vi.fn<(resp: ActionResponseOk<{ n: number }>) => void>();
+
+    wrapAction(action, onSuccess)();
+    await flush();
+
+    expect(onSuccess).toHaveBeenCalledWith({ ok: true, data: { n: 7 } });
+  });
+
+  it("logs an error response and does not call onSuccess", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const action = (): Promise<ActionResponse> =>
+      Promise.resolve(error("Not signed in"));
+    const onSuccess = vi.fn();
+
+    wrapAction(action, onSuccess)();
+    await flush();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Server action returned error: ",
+      "Not signed in",
+    );
+  });
+
+  it("catches a rejected action instead of leaving an unhandled rejection", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const boom = new Error("boom");
+    const action = (): Promise<ActionResponse> => Promise.reject(boom);
+
+    expect(() => wrapAction(action)()).not.toThrow();
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledWith(boom);
+  });
+
+  it("treats an undefined response (post-redirect) as a no-op with a warning", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    // Next.js server actions that redirect resolve to undefined on the client.
+    const action = () =>
+      Promise.resolve(undefined) as unknown as Promise<ActionResponse>;
+    const onSuccess = vi.fn();
+
+    wrapAction(action, onSuccess)();
+    await flush();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,59 @@
+// `.mts` so Vite loads this as ESM: package.json has no `"type": "module"`,
+// and Vitest's CommonJS entry cannot require its ESM dependencies on Node 22.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+// Mirror tsconfig.json: `@/x` -> `./x`, and the bare `auth` import -> `./auth.ts`.
+const alias = [
+  { find: /^@\/(.*)$/, replacement: path.join(root, "$1") },
+  { find: /^auth$/, replacement: path.join(root, "auth.ts") },
+];
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias },
+  test: {
+    projects: [
+      {
+        // Pure functions in lib/. No DOM, no database.
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["test/unit/**/*.test.ts"],
+        },
+      },
+      {
+        // React components rendered with Testing Library in happy-dom.
+        // (jsdom 27 needs require(esm), which Node 22.8 in .nvmrc lacks.)
+        extends: true,
+        test: {
+          name: "components",
+          environment: "happy-dom",
+          include: ["test/unit/**/*.test.tsx"],
+          setupFiles: ["test/setup-dom.ts"],
+        },
+      },
+      {
+        // Server actions and route handlers against a real Postgres database.
+        // Requires DATABASE_URL (see .env.test) and `npm run test:db`.
+        extends: true,
+        test: {
+          name: "integration",
+          environment: "node",
+          include: ["test/integration/**/*.test.ts"],
+          globalSetup: ["test/integration/global-setup.ts"],
+          setupFiles: ["test/integration/setup.ts"],
+          // Every file shares one database, so files must not run concurrently.
+          fileParallelism: false,
+          testTimeout: 15_000,
+          hookTimeout: 30_000,
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## What

Adds a test suite and CI for it. Nothing in `app/`, `lib/`, or `components/` changes.

**Stack:** Vitest 4, split into three projects in `vitest.config.mts`:

| Project | What it covers | Env | Command |
|---|---|---|---|
| `unit` | `lib/permissions.ts`, `lib/filter.ts`, `lib/server-actions.ts` | node | `npm test` |
| `components` | `AimeInput`, `IntegerInput` via Testing Library | happy-dom | `npm test` |
| `integration` | every server action + `GET /api/collections/[cid]/problems` | node + real Postgres | `npm run test:db && npm run test:integration` |

**Why a real database for integration tests:** almost all the app's logic is in Prisma queries (pid generation via `startsWith` + `orderBy id desc`, upserts, unique constraints, cascade deletes). Mocking Prisma would test the mock. Only `auth()` and `next/cache` are mocked; `redirect()` / `notFound()` are real and asserted via their thrown errors.

**Safety:** the integration DB is a throwaway `postgres:16` container on port **5433** (`docker-compose.test.yml`, data on tmpfs), configured in the committed, secret-free `.env.test`. Every table is truncated before each test, so `test/integration/global-setup.ts` refuses to run against any database whose name does not end in `_test`. It cannot touch the dev DB on 5432 or production.

**CI:** `.github/workflows/test.yml` runs both suites on every PR and push to `main`, with a Postgres service on the same port/credentials so `.env.test` works unchanged.

## Notable behaviours pinned by tests

- Anonymous edits in the `demo` collection are allowed (intentional per CLAUDE.md).
- Testsolve submissions get a 10 s grace buffer past the time limit; giving up does not.
- Submission cap of 5; `remaining` counts down to 0.
- Invite email domain uses `endsWith("@" + domain)`, so `x@notmit.edu` is rejected for `mit.edu`.
- `topsoj` / `mgci` invites force `testsolverType: Serious` dated from the collection's creation.
- The API route's `"Empty token"` branch is unreachable over HTTP because header values are trimmed; the test asserts the 401 only.

## Things I noticed but did not change

- `acceptInvite` treats **any** non-null `expiresAt` as expired, including future dates. The test uses a past date so it does not enshrine that.
- Node 22.8 (`.nvmrc`) cannot `require()` ESM, which rules out jsdom ≥ 27; happy-dom is used instead. Bumping to Node ≥ 22.12 would remove that constraint and also let `vitest.config` be a plain `.ts`.

## Verification

- `npm run lint` — only the 16 pre-existing warnings, none in `test/`
- `npx prettier . --check` — clean
- `npm test` — 74 passed
- `npm run test:integration` — 88 passed
- `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCUqHHukA4ZvLeDVeQ1Cfy
