### PR TITLE
ci: run lint, typecheck and build on pull requests

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Prettier Check Code Format
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,20 @@ on:
   pull_request:
 
 jobs:
+  lint-and-build:
+    name: Lint, typecheck and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm run build
+
   unit:
     name: Unit and component tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ next-env.d.ts
 
 # cursor
 .cursor
+# claude code worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Problem

CI ran the Prettier check and both test suites but not `next lint`, `tsc`, or `next build`. CLAUDE.md lists all of those as the verification gates, so a type error or a `no-floating-promises` violation could merge with green checks. The Prettier workflow also pinned Node 18 while `.nvmrc` says 22, and `prettier . --check` failed locally whenever another Claude Code worktree had a `.next` directory under `.claude/worktrees/`.

## Why this approach

Adding one job to the existing `test.yml` keeps the workflow count at two and reuses the same setup steps. Ignoring `.claude/worktrees/` in `.gitignore` fixes Prettier (which honours `.gitignore` by default) and also prevents a worktree from ever being committed by accident.

## What changed

- `test.yml`: new `lint-and-build` job running `npm run lint`, `npx tsc --noEmit`, `npm run build`.
- `prettier-check.yml`: `node-version-file: .nvmrc` with npm cache.
- `.gitignore`: `.claude/worktrees/`.

## Visible behavior changes

None. CI only.

## Verification

- Local: `npm run lint`, `npx tsc --noEmit`, `npm run build`, and `npx prettier . --check` all pass on this branch.
- The new job's first run is this PR's own check.

## Residual risk

The build job adds roughly a minute to CI wall time. It runs in parallel with the other jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
