### PR TITLE
refactor: add request context helpers and use them everywhere

### DIFF
--- a/app/c/[cid]/add-problem/actions.ts
+++ b/app/c/[cid]/add-problem/actions.ts
@@ -4,7 +4,8 @@ import { canAddProblem } from "@/lib/permissions";
 import prisma from "@/lib/prisma";
 import { ActionResponse, error } from "@/lib/server-actions";
 import { Subject } from "@prisma/client";
-import { auth } from "auth";
+import { getCurrentUser } from "@/lib/current-user";
+import { getPermission } from "@/lib/collection-access";
 import { revalidateTag } from "next/cache";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { redirect } from "next/navigation";
@@ -20,15 +21,11 @@ export async function addProblem(
   collectionId: number,
   formData: FormData,
 ): Promise<ActionResponse> {
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   const title = formData.get("title") as string;
   const subject = formData.get("subject") as Subject;
@@ -47,14 +44,7 @@ export async function addProblem(
       return error("Collection not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId,
-        },
-      },
-    });
+    const permission = await getPermission(userId, collectionId);
     if (!canAddProblem(permission)) {
       return error("You do not have permission to add a problem");
     }
@@ -123,7 +113,7 @@ export async function addProblem(
           create: {
             user: {
               connect: {
-                id: session.userId,
+                id: userId,
               },
             },
           },

--- a/app/c/[cid]/add-problem/page.tsx
+++ b/app/c/[cid]/add-problem/page.tsx
@@ -1,8 +1,9 @@
 import ProblemForm from "./problem-form";
 import prisma from "@/lib/prisma";
 import { Session } from "next-auth";
-import { notFound, redirect } from "next/navigation";
-import { auth } from "auth";
+import { notFound } from "next/navigation";
+import { requireCurrentUser, type CurrentUser } from "@/lib/current-user";
+import { getAuthorIds } from "@/lib/collection-access";
 
 interface Params {
   cid: string;
@@ -17,22 +18,11 @@ function getFullName(session: Session): string {
 }
 
 async function getOrCreateAuthor(
-  session: Session,
+  { userId, session }: CurrentUser,
   collectionId: number,
 ): Promise<number> {
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("userId is undefined despite being logged in");
-  }
-
   // Check if user already has author
-  const authors = await prisma.author.findMany({
-    where: {
-      userId,
-      collectionId,
-    },
-    select: { id: true },
-  });
+  const authors = await getAuthorIds(userId, collectionId);
   if (authors.length > 0) {
     return authors[0].id;
   }
@@ -65,16 +55,12 @@ async function getCollection(cid: string) {
 
 export default async function AddProblemPage({ params }: { params: Params }) {
   const { cid } = params;
-  const session = await auth();
-  if (session === null) {
-    // Not logged in
-    redirect(`/api/auth/signin?callbackUrl=%2Fc%2F${cid}%2Fadd-problem`);
-  }
+  const user = await requireCurrentUser(`/c/${cid}/add-problem`);
 
   // TODO: select only needed fields of collection
   const collection = await getCollection(cid);
   // TODO: ViewOnly should see a different page explaining why they can't submit
-  const authorId = await getOrCreateAuthor(session, collection.id);
+  const authorId = await getOrCreateAuthor(user, collection.id);
 
   return <ProblemForm collection={collection} authorId={authorId} />;
 }

--- a/app/c/[cid]/choose-testsolver-type/actions.ts
+++ b/app/c/[cid]/choose-testsolver-type/actions.ts
@@ -3,7 +3,8 @@
 import { notFound, redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { ActionResponse, error } from "@/lib/server-actions";
-import { auth } from "auth";
+import { getCurrentUser } from "@/lib/current-user";
+import { getPermission } from "@/lib/collection-access";
 import { TestsolverType } from "@prisma/client";
 
 export async function setTestsolverType(
@@ -12,15 +13,11 @@ export async function setTestsolverType(
 ): Promise<ActionResponse> {
   // TODO: zod
 
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   const collection = await prisma.collection.findUnique({
     where: { id: collectionId },
@@ -29,14 +26,7 @@ export async function setTestsolverType(
     notFound();
   }
 
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId,
-      },
-    },
-  });
+  const permission = await getPermission(userId, collectionId);
 
   if (permission === null) {
     return error("You do not have access to this collection");

--- a/app/c/[cid]/choose-testsolver-type/page.tsx
+++ b/app/c/[cid]/choose-testsolver-type/page.tsx
@@ -1,20 +1,7 @@
-import prisma from "@/lib/prisma";
-import { notFound, redirect } from "next/navigation";
-import { canViewCollection } from "@/lib/permissions";
-import { Collection } from "@prisma/client";
-import { auth } from "auth";
+import { redirect } from "next/navigation";
+import { requireCollectionAccess } from "@/lib/collection-access";
 import ChooseTestsolverTypePage from "@/components/choose-testsolver-type-page";
 import { setTestsolverType } from "./actions";
-
-async function getCollection(cid: string): Promise<Collection> {
-  const collection = await prisma.collection.findUnique({
-    where: { cid },
-  });
-  if (collection === null) {
-    notFound();
-  }
-  return collection;
-}
 
 interface Params {
   cid: string;
@@ -22,31 +9,9 @@ interface Params {
 
 export default async function Page({ params }: { params: Params }) {
   const { cid } = params;
-  const collection = await getCollection(cid);
-
-  const session = await auth();
-
-  if (session === null) {
-    redirect(`/api/auth/signin?callbackUrl=%2Fc%2F${cid}`);
-  }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("userId is undefined despite being logged in");
-  }
-
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: collection.id,
-      },
-    },
+  const { collection } = await requireCollectionAccess(cid, `/c/${cid}`, {
+    skipTestsolverTypeCheck: true,
   });
-
-  if (permission === null || !canViewCollection(permission)) {
-    redirect("/need-permission");
-  }
 
   if (collection.requireTestsolve === false) {
     redirect(`/c/${cid}`);

--- a/app/c/[cid]/p/[pid]/actions.ts
+++ b/app/c/[cid]/p/[pid]/actions.ts
@@ -10,7 +10,8 @@ import {
 import prisma from "@/lib/prisma";
 import { type ActionResponse, error } from "@/lib/server-actions";
 import { Prisma } from "@prisma/client";
-import { auth } from "auth";
+import { getCurrentUser } from "@/lib/current-user";
+import { getAuthorIds, getPermission } from "@/lib/collection-access";
 import { revalidateTag } from "next/cache";
 
 export async function likeProblem(
@@ -36,25 +37,14 @@ export async function likeProblem(
       return error(`No problem with id ${problemId}`);
     }
 
-    const session = await auth();
-    if (session === null) {
+    const user = await getCurrentUser();
+    if (user === null) {
       return error("Not signed in");
     }
-
-    const userId = session.userId;
-    if (userId === undefined) {
-      return error("userId is undefined despite being logged in");
-    }
+    const { userId } = user;
 
     const collectionId = problem.collection.id;
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId,
-        },
-      },
-    });
+    const permission = await getPermission(userId, collectionId);
     if (!canViewCollection(permission)) {
       // No permission
       return error("You do not have permission to like this problem");
@@ -137,32 +127,15 @@ export async function editProblem(
       return error(`No problem with id ${problemId}`);
     }
 
-    const session = await auth();
-    if (session === null) {
+    const user = await getCurrentUser();
+    if (user === null) {
       return error("Not signed in");
     }
-
-    const userId = session.userId;
-    if (userId === undefined) {
-      return error("userId is undefined despite being logged in");
-    }
+    const { userId } = user;
 
     const collectionId = problem.collection.id;
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId,
-        },
-      },
-    });
-    const authors = await prisma.author.findMany({
-      where: {
-        userId,
-        collectionId,
-      },
-      select: { id: true },
-    });
+    const permission = await getPermission(userId, collectionId);
+    const authors = await getAuthorIds(userId, collectionId);
     if (!canEditProblem(problem, permission, authors)) {
       // No permission
       return error("You do not have permission to edit this problem");
@@ -198,15 +171,11 @@ export async function addComment(
     return error("Text is null");
   }
 
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const problem = await prisma.problem.findUnique({
@@ -224,14 +193,7 @@ export async function addComment(
       return error("Problem not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId: problem.collection.id,
-        },
-      },
-    });
+    const permission = await getPermission(userId, problem.collection.id);
     if (!canAddComment(permission)) {
       return error("You do not have permission to comment on this problem");
     }
@@ -258,15 +220,11 @@ export async function addComment(
 export async function startTestsolve(
   problemId: number,
 ): Promise<ActionResponse> {
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const problem = await prisma.problem.findUnique({
@@ -286,14 +244,7 @@ export async function startTestsolve(
       return error("Problem not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId: problem.collection.id,
-        },
-      },
-    });
+    const permission = await getPermission(userId, problem.collection.id);
     // TODO: use canTestsolveProblem
     if (!canViewCollection(permission)) {
       return error("You do not have permission to edit this collection");
@@ -321,15 +272,11 @@ export async function submitTestsolve(
 ): Promise<ActionResponse<{ correct: boolean; remaining: number }>> {
   const submittedAt = new Date();
 
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const problem = await prisma.problem.findUnique({
@@ -351,14 +298,7 @@ export async function submitTestsolve(
       return error("Problem not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId: problem.collection.id,
-        },
-      },
-    });
+    const permission = await getPermission(userId, problem.collection.id);
     // TODO: use canTestsolveProblem
     if (!canViewCollection(permission)) {
       return error("You do not have permission to edit this collection");
@@ -429,15 +369,11 @@ export async function giveUpTestsolve(
 ): Promise<ActionResponse> {
   const submittedAt = new Date();
 
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const problem = await prisma.problem.findUnique({
@@ -459,14 +395,7 @@ export async function giveUpTestsolve(
       return error("Problem not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId: problem.collection.id,
-        },
-      },
-    });
+    const permission = await getPermission(userId, problem.collection.id);
     // TODO: use canTestsolveProblem
     if (!canViewCollection(permission)) {
       return error("You do not have permission to edit this collection");
@@ -521,15 +450,11 @@ export async function addSolution(
   text: string,
   authorId: number,
 ): Promise<ActionResponse> {
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const problem = await prisma.problem.findUnique({
@@ -539,14 +464,7 @@ export async function addSolution(
       return error("Problem not found");
     }
 
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId: problem.collectionId,
-        },
-      },
-    });
+    const permission = await getPermission(userId, problem.collectionId);
     if (!canAddSolution(permission)) {
       return error("You do not have permission to edit this collection");
     }
@@ -574,15 +492,11 @@ export async function editSolution(
   solutionId: number,
   text: string,
 ): Promise<ActionResponse> {
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
+  const { userId } = user;
 
   try {
     const solution = await prisma.solution.findUnique({
@@ -610,21 +524,8 @@ export async function editSolution(
     }
 
     const collectionId = solution.problem.collection.id;
-    const permission = await prisma.permission.findUnique({
-      where: {
-        userId_collectionId: {
-          userId,
-          collectionId,
-        },
-      },
-    });
-    const authors = await prisma.author.findMany({
-      where: {
-        userId,
-        collectionId,
-      },
-      select: { id: true },
-    });
+    const permission = await getPermission(userId, collectionId);
+    const authors = await getAuthorIds(userId, collectionId);
     if (!canEditSolution(solution, permission, authors)) {
       return error("You do not have permission to edit this collection");
     }

--- a/app/c/[cid]/p/[pid]/answer.tsx
+++ b/app/c/[cid]/p/[pid]/answer.tsx
@@ -5,7 +5,7 @@ import { canEditProblem } from "@/lib/permissions";
 import Label from "@/components/label";
 
 export default function Answer(props: Props) {
-  const { problem, collection, permission, authors } = props;
+  const { problem, permission, authors } = props;
   const canEdit = canEditProblem(problem, permission, authors);
   const label = <Label text="ANSWER" />;
 

--- a/app/c/[cid]/p/[pid]/page.tsx
+++ b/app/c/[cid]/p/[pid]/page.tsx
@@ -1,21 +1,16 @@
 import prisma from "@/lib/prisma";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import ProblemPage from "./problem-page";
 import { problemInclude, type Params, type Props } from "./types";
-import { canViewCollection } from "@/lib/permissions";
-import { auth } from "auth";
+import { requireCollectionAccess } from "@/lib/collection-access";
 import { parseFilter } from "@/lib/filter";
 
 // TODO: params can be null, but the type does not reflect that
-async function getProps(params: Params, userId: string): Promise<Props> {
+async function getProps(params: Params): Promise<Props> {
   const { cid, pid } = params;
 
-  const collection = await prisma.collection.findUnique({
-    where: { cid },
-  });
-  if (collection === null) {
-    notFound();
-  }
+  const { userId, collection, permission, authors } =
+    await requireCollectionAccess(cid, `/c/${cid}/p/${pid}`);
 
   const problem = await prisma.problem.findUnique({
     where: {
@@ -29,33 +24,6 @@ async function getProps(params: Params, userId: string): Promise<Props> {
   if (problem === null) {
     notFound();
   }
-
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: collection.id,
-      },
-    },
-  });
-
-  // canViewCollection already checks for null, but we include it here so TypeScript knows that permission is non-null later in the program
-  if (permission === null || !canViewCollection(permission)) {
-    // No permission to view this page
-    redirect("/need-permission");
-  }
-
-  if (collection.requireTestsolve && permission.testsolverType === null) {
-    redirect(`/c/${cid}/choose-testsolver-type`);
-  }
-
-  const authors = await prisma.author.findMany({
-    where: {
-      userId,
-      collectionId: collection.id,
-    },
-    select: { id: true },
-  });
 
   const props: Props = {
     problem,
@@ -75,20 +43,8 @@ export default async function Page({
   params: Params;
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const { cid, pid } = params;
   const filter = parseFilter(searchParams);
-  const session = await auth();
-  if (session === null) {
-    // Not logged in
-    redirect(`/api/auth/signin?callbackUrl=%2Fc%2F${cid}%2Fp%2F${pid}`);
-  }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("userId is undefined despite being logged in");
-  }
-
-  const props: Props = await getProps(params, userId);
+  const props: Props = await getProps(params);
 
   return <ProblemPage {...props} filter={filter} />;
 }

--- a/app/c/[cid]/p/[pid]/solution.tsx
+++ b/app/c/[cid]/p/[pid]/solution.tsx
@@ -1,22 +1,15 @@
 import EditableSolution from "./editable-solution";
 import Latex from "@/components/latex";
-import type {
-  AuthorProps,
-  CollectionProps,
-  PermissionProps,
-  SolutionProps,
-} from "./types";
+import type { AuthorProps, PermissionProps, SolutionProps } from "./types";
 import { canEditSolution } from "@/lib/permissions";
 import Label from "@/components/label";
 
 export default function Solution({
   solution,
-  collection,
   permission,
   authors,
 }: {
   solution: SolutionProps;
-  collection: CollectionProps;
   permission: PermissionProps;
   authors: AuthorProps[];
 }) {

--- a/app/c/[cid]/p/[pid]/spoilers.tsx
+++ b/app/c/[cid]/p/[pid]/spoilers.tsx
@@ -7,7 +7,7 @@ import AddSolution from "./add-solution";
 import type { Props } from "./types";
 
 export default function Spoilers(props: Props) {
-  const { problem, collection, permission, authors } = props;
+  const { problem, permission, authors } = props;
   const [hidden, setHidden] = useState(true);
 
   let answer, solution;
@@ -25,12 +25,7 @@ export default function Spoilers(props: Props) {
     const sol = problem.solutions[0];
     solution = (
       <div className="my-8">
-        <Solution
-          solution={sol}
-          collection={collection}
-          permission={permission}
-          authors={authors}
-        />
+        <Solution solution={sol} permission={permission} authors={authors} />
       </div>
     );
   } else if (authors.length > 0) {

--- a/app/c/[cid]/p/[pid]/statement.tsx
+++ b/app/c/[cid]/p/[pid]/statement.tsx
@@ -4,7 +4,7 @@ import type { Props } from "./types";
 import { canEditProblem } from "@/lib/permissions";
 
 export default function Statement(props: Props) {
-  const { problem, collection, permission, authors } = props;
+  const { problem, permission, authors } = props;
   const canEdit = canEditProblem(problem, permission, authors);
 
   if (canEdit) {

--- a/app/c/[cid]/p/[pid]/title.tsx
+++ b/app/c/[cid]/p/[pid]/title.tsx
@@ -10,7 +10,7 @@ const subjectToTextColor = {
 };
 
 export default function Title(props: Props) {
-  const { problem, collection, permission, authors } = props;
+  const { problem, permission, authors } = props;
   const canEdit = canEditProblem(problem, permission, authors);
 
   return (

--- a/app/c/[cid]/page.tsx
+++ b/app/c/[cid]/page.tsx
@@ -1,21 +1,9 @@
 import prisma from "@/lib/prisma";
-import { notFound, redirect } from "next/navigation";
-import { canViewCollection } from "@/lib/permissions";
 import ProblemList from "./problem-list";
 import { Collection, Problem } from "@prisma/client";
 import { ProblemProps } from "./types";
-import { auth } from "auth";
+import { requireCollectionAccess } from "@/lib/collection-access";
 import { parseFilter } from "@/lib/filter";
-
-async function getCollection(cid: string): Promise<Collection> {
-  const collection = await prisma.collection.findUnique({
-    where: { cid },
-  });
-  if (collection === null) {
-    notFound();
-  }
-  return collection;
-}
 
 function sortByNew(p1: Problem, p2: Problem): number {
   const t1 = p1.createdAt;
@@ -74,50 +62,9 @@ export default async function Page({
 }) {
   const { cid } = params;
   const filter = parseFilter(searchParams);
-  const collection = await getCollection(cid);
+  const { userId, collection, permission, authors } =
+    await requireCollectionAccess(cid, `/c/${cid}`);
   const problems = await getProblems(collection);
-
-  // This call is still slow.
-  // Private pages must wait for security check
-  // Public pages can show the problems immediately, and stream personalized data as the page loads
-  const session = await auth();
-
-  if (session === null) {
-    // Not logged in
-    redirect(`/api/auth/signin?callbackUrl=%2Fc%2F${cid}`);
-  }
-
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("userId is undefined despite being logged in");
-  }
-
-  const authors = await prisma.author.findMany({
-    where: {
-      userId,
-      collectionId: collection.id,
-    },
-    select: { id: true },
-  });
-
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: collection.id,
-      },
-    },
-  });
-
-  // canViewCollection already checks for null, but we include it here so TypeScript knows that permission is non-null later in the program
-  if (permission === null || !canViewCollection(permission)) {
-    // No permission
-    redirect("/need-permission");
-  }
-
-  if (collection.requireTestsolve && permission.testsolverType === null) {
-    redirect(`/c/${cid}/choose-testsolver-type`);
-  }
 
   const solvedAttempts = await prisma.solveAttempt.findMany({
     where: {

--- a/app/c/[cid]/t/[testSlug]/page.tsx
+++ b/app/c/[cid]/t/[testSlug]/page.tsx
@@ -1,7 +1,8 @@
 import prisma from "@/lib/prisma";
 import { notFound, redirect } from "next/navigation";
 import TestPage from "./test-page";
-import { auth } from "auth";
+import { requireCurrentUser } from "@/lib/current-user";
+import { getAuthorIds, getPermission } from "@/lib/collection-access";
 import { canViewCollection } from "@/lib/permissions";
 
 interface Params {
@@ -27,26 +28,9 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  const session = await auth();
-  if (session === null) {
-    redirect(`/api/auth/signin?callbackUrl=%2Fc%2F${cid}%2Ft%2F${testSlug}`);
-  }
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("userId is undefined despite being logged in");
-  }
+  const { userId } = await requireCurrentUser(`/c/${cid}/t/${testSlug}`);
 
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: test.collectionId,
-      },
-    },
-    select: {
-      accessLevel: true,
-    },
-  });
+  const permission = await getPermission(userId, test.collectionId);
   if (permission === null || !canViewCollection(permission)) {
     redirect("/need-permission");
   }
@@ -54,13 +38,7 @@ export default async function Page({ params }: { params: Params }) {
   const solveAttempts = await prisma.solveAttempt.findMany({
     where: { userId },
   });
-  const authors = await prisma.author.findMany({
-    where: {
-      userId,
-      collectionId: test.collectionId,
-    },
-    select: { id: true },
-  });
+  const authors = await getAuthorIds(userId, test.collectionId);
 
   const testProblems = await prisma.testProblem.findMany({
     where: {

--- a/app/invite/[code]/actions.ts
+++ b/app/invite/[code]/actions.ts
@@ -3,23 +3,19 @@
 import { redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { ActionResponse, error } from "@/lib/server-actions";
-import { auth } from "auth";
+import { getCurrentUser } from "@/lib/current-user";
 
 export async function acceptInvite(
   inviteCode: string,
 ): Promise<ActionResponse> {
   // TODO: zod
-  const session = await auth();
-  if (session === null) {
+  const user = await getCurrentUser();
+  if (user === null) {
     return error("Not signed in");
   }
+  const { userId } = user;
 
-  const userId = session.userId;
-  if (userId === undefined) {
-    return error("userId is undefined despite being logged in");
-  }
-
-  const email = session.currentEmail;
+  const email = user.session.currentEmail;
   if (email === null || email === undefined) {
     return error("session.email is null or undefined");
   }

--- a/app/invite/[code]/page.tsx
+++ b/app/invite/[code]/page.tsx
@@ -5,7 +5,8 @@ import Expired from "./expired";
 import InvalidEmail from "./invalid-email";
 import type { InviteProps } from "./types";
 import { inviteInclude } from "./types";
-import { auth } from "auth";
+import { getCurrentUser } from "@/lib/current-user";
+import { getPermission } from "@/lib/collection-access";
 import InviteJoinPage from "./invite-join-page";
 import AlreadyJoined from "./already-joined";
 
@@ -27,33 +28,21 @@ async function getInvite(code: string): Promise<InviteProps> {
 }
 
 export default async function InvitePage({ params }: { params: Params }) {
-  const session = await auth();
+  const user = await getCurrentUser();
 
   const { code } = params;
   const invite = await getInvite(code);
 
-  if (session === null) {
+  if (user === null) {
     return <NotLoggedIn invite={invite} />;
   }
 
-  const email = session.currentEmail;
+  const email = user.session.currentEmail;
   if (email === null || email === undefined) {
     throw new Error("session.email is null or undefined");
   }
 
-  const userId = session.userId;
-  if (userId === undefined) {
-    throw new Error("session.userId is undefined");
-  }
-
-  const permission = await prisma.permission.findUnique({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: invite.collectionId,
-      },
-    },
-  });
+  const permission = await getPermission(user.userId, invite.collectionId);
 
   if (
     permission !== null &&

--- a/lib/collection-access.ts
+++ b/lib/collection-access.ts
@@ -1,0 +1,80 @@
+import type { Collection, Permission } from "@prisma/client";
+import { notFound, redirect } from "next/navigation";
+import prisma from "@/lib/prisma";
+import { canViewCollection } from "@/lib/permissions";
+import { requireCurrentUser, type CurrentUser } from "@/lib/current-user";
+
+export function getPermission(
+  userId: string,
+  collectionId: number,
+): Promise<Permission | null> {
+  return prisma.permission.findUnique({
+    where: {
+      userId_collectionId: {
+        userId,
+        collectionId,
+      },
+    },
+  });
+}
+
+/** The Author rows this user writes under in the collection. Usually zero or one. */
+export function getAuthorIds(
+  userId: string,
+  collectionId: number,
+): Promise<{ id: number }[]> {
+  return prisma.author.findMany({
+    where: {
+      userId,
+      collectionId,
+    },
+    select: { id: true },
+  });
+}
+
+export interface CollectionAccess extends CurrentUser {
+  collection: Collection;
+  permission: Permission;
+  authors: { id: number }[];
+}
+
+/**
+ * For pages under /c/[cid]. In order:
+ *  - 404 if the collection does not exist
+ *  - redirect to sign-in (returning to `callbackPath`) if signed out
+ *  - redirect to /need-permission if the user cannot view the collection
+ *  - redirect to the testsolver-type chooser if the collection requires
+ *    testsolving and the user has not picked a type yet (unless
+ *    `skipTestsolverTypeCheck`, which the chooser page itself needs)
+ */
+export async function requireCollectionAccess(
+  cid: string,
+  callbackPath: string,
+  options: { skipTestsolverTypeCheck?: boolean } = {},
+): Promise<CollectionAccess> {
+  const collection = await prisma.collection.findUnique({
+    where: { cid },
+  });
+  if (collection === null) {
+    notFound();
+  }
+
+  const user = await requireCurrentUser(callbackPath);
+
+  const permission = await getPermission(user.userId, collection.id);
+  if (permission === null || !canViewCollection(permission)) {
+    redirect("/need-permission");
+  }
+
+  if (
+    !options.skipTestsolverTypeCheck &&
+    collection.requireTestsolve &&
+    permission.testsolverType === null
+  ) {
+    redirect(`/c/${cid}/choose-testsolver-type`);
+  }
+
+  const authors = await getAuthorIds(user.userId, collection.id);
+
+  return { ...user, collection, permission, authors };
+}

--- a/lib/current-user.ts
+++ b/lib/current-user.ts
@@ -1,0 +1,43 @@
+import type { Session } from "next-auth";
+import { redirect } from "next/navigation";
+import { auth } from "auth";
+
+export interface CurrentUser {
+  userId: string;
+  session: Session;
+}
+
+/**
+ * The signed-in user, or null when there is no session.
+ *
+ * Throws if the session has no user id. That is an auth misconfiguration
+ * (the jwt callback in auth.ts always sets `sub`), not a signed-out user,
+ * so callers do not need to handle it.
+ */
+export async function getCurrentUser(): Promise<CurrentUser | null> {
+  const session = await auth();
+  if (session === null) {
+    return null;
+  }
+  const userId = session.userId;
+  if (userId === undefined) {
+    throw new Error("userId is undefined despite being logged in");
+  }
+  return { userId, session };
+}
+
+/**
+ * For pages: the signed-in user, or a redirect to the sign-in page that
+ * returns to `callbackPath` once they have signed in.
+ */
+export async function requireCurrentUser(
+  callbackPath: string,
+): Promise<CurrentUser> {
+  const user = await getCurrentUser();
+  if (user === null) {
+    redirect(
+      `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackPath)}`,
+    );
+  }
+  return user;
+}

--- a/test/integration/lib/collection-access.test.ts
+++ b/test/integration/lib/collection-access.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAuthorIds,
+  getPermission,
+  requireCollectionAccess,
+} from "@/lib/collection-access";
+import {
+  createAuthor,
+  createCollection,
+  createPermission,
+  createUser,
+} from "../factories";
+import { expectNotFound, expectRedirect } from "../navigation";
+import { signInAs, signOut } from "../session";
+
+describe("getPermission", () => {
+  it("returns the user's permission row for the collection, or null", async () => {
+    const collection = await createCollection();
+    const user = await createUser();
+    expect(await getPermission(user.id, collection.id)).toBeNull();
+
+    const permission = await createPermission(user, collection, "ViewOnly");
+    expect(await getPermission(user.id, collection.id)).toEqual(permission);
+  });
+});
+
+describe("getAuthorIds", () => {
+  it("returns only the user's authors in that collection", async () => {
+    const collection = await createCollection();
+    const other = await createCollection();
+    const user = await createUser();
+    const mine = await createAuthor(collection, { userId: user.id });
+    await createAuthor(other, { userId: user.id });
+    await createAuthor(collection);
+
+    expect(await getAuthorIds(user.id, collection.id)).toEqual([
+      { id: mine.id },
+    ]);
+  });
+});
+
+describe("requireCollectionAccess", () => {
+  it("404s for an unknown collection, even when signed out", async () => {
+    signOut();
+    await expectNotFound(requireCollectionAccess("nope", "/c/nope"));
+  });
+
+  it("redirects a signed-out user to sign-in, returning to the callback path", async () => {
+    const collection = await createCollection();
+    signOut();
+    await expectRedirect(
+      requireCollectionAccess(collection.cid, `/c/${collection.cid}`),
+      `/api/auth/signin?callbackUrl=%2Fc%2F${collection.cid}`,
+    );
+  });
+
+  it("redirects a user with no permission row to /need-permission", async () => {
+    const collection = await createCollection();
+    signInAs(await createUser());
+    await expectRedirect(
+      requireCollectionAccess(collection.cid, "/x"),
+      "/need-permission",
+    );
+  });
+
+  it("redirects a SubmitOnly user, who cannot view the collection", async () => {
+    const collection = await createCollection();
+    const user = await createUser();
+    await createPermission(user, collection, "SubmitOnly");
+    signInAs(user);
+    await expectRedirect(
+      requireCollectionAccess(collection.cid, "/x"),
+      "/need-permission",
+    );
+  });
+
+  it("returns the collection, permission, authors and user for a member", async () => {
+    const collection = await createCollection();
+    const user = await createUser();
+    const permission = await createPermission(user, collection, "TeamMember");
+    const author = await createAuthor(collection, { userId: user.id });
+    signInAs(user);
+
+    const access = await requireCollectionAccess(collection.cid, "/x");
+
+    expect(access.userId).toBe(user.id);
+    expect(access.collection).toEqual(collection);
+    expect(access.permission).toEqual(permission);
+    expect(access.authors).toEqual([{ id: author.id }]);
+  });
+
+  describe("collections that require testsolving", () => {
+    it("sends a member who has not chosen a testsolver type to the chooser", async () => {
+      const collection = await createCollection({ requireTestsolve: true });
+      const user = await createUser();
+      await createPermission(user, collection, "TeamMember");
+      signInAs(user);
+
+      await expectRedirect(
+        requireCollectionAccess(collection.cid, "/x"),
+        `/c/${collection.cid}/choose-testsolver-type`,
+      );
+    });
+
+    it("lets a member through once they have chosen a type", async () => {
+      const collection = await createCollection({ requireTestsolve: true });
+      const user = await createUser();
+      await createPermission(user, collection, "TeamMember", {
+        testsolverType: "Casual",
+      });
+      signInAs(user);
+
+      const access = await requireCollectionAccess(collection.cid, "/x");
+      expect(access.permission.testsolverType).toBe("Casual");
+    });
+
+    it("skips the chooser redirect when asked, for the chooser page itself", async () => {
+      const collection = await createCollection({ requireTestsolve: true });
+      const user = await createUser();
+      await createPermission(user, collection, "TeamMember");
+      signInAs(user);
+
+      const access = await requireCollectionAccess(collection.cid, "/x", {
+        skipTestsolverTypeCheck: true,
+      });
+      expect(access.permission.testsolverType).toBeNull();
+    });
+
+    it("does not redirect members of collections without testsolving", async () => {
+      const collection = await createCollection({ requireTestsolve: false });
+      const user = await createUser();
+      await createPermission(user, collection, "TeamMember");
+      signInAs(user);
+
+      const access = await requireCollectionAccess(collection.cid, "/x");
+      expect(access.permission.testsolverType).toBeNull();
+    });
+  });
+});

--- a/test/unit/lib/current-user.test.ts
+++ b/test/unit/lib/current-user.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "next-auth";
+import { auth } from "auth";
+import { getCurrentUser, requireCurrentUser } from "@/lib/current-user";
+import { expectRedirect } from "../../integration/navigation";
+
+vi.mock("auth", () => ({ auth: vi.fn() }));
+const mockedAuth = vi.mocked(auth as () => Promise<Session | null>);
+
+const session = {
+  expires: "2030-01-01T00:00:00.000Z",
+  userId: "user-1",
+  currentEmail: "user@example.com",
+  emailVerified: true,
+} as Session;
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+});
+
+describe("getCurrentUser", () => {
+  it("returns null when signed out", async () => {
+    mockedAuth.mockResolvedValue(null);
+    expect(await getCurrentUser()).toBeNull();
+  });
+
+  it("returns the user id and the session when signed in", async () => {
+    mockedAuth.mockResolvedValue(session);
+    expect(await getCurrentUser()).toEqual({ userId: "user-1", session });
+  });
+
+  it("throws when a session has no user id, which is a misconfiguration", async () => {
+    mockedAuth.mockResolvedValue({ ...session, userId: undefined });
+    await expect(getCurrentUser()).rejects.toThrow(
+      "userId is undefined despite being logged in",
+    );
+  });
+});
+
+describe("requireCurrentUser", () => {
+  it("returns the user when signed in", async () => {
+    mockedAuth.mockResolvedValue(session);
+    expect(await requireCurrentUser("/c/x")).toEqual({
+      userId: "user-1",
+      session,
+    });
+  });
+
+  it("redirects to sign-in with the encoded callback path when signed out", async () => {
+    mockedAuth.mockResolvedValue(null);
+    await expectRedirect(
+      requireCurrentUser("/c/x/p/A1"),
+      "/api/auth/signin?callbackUrl=%2Fc%2Fx%2Fp%2FA1",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Every server action and page repeated the same prologue: `auth()`, null-session check, undefined-`userId` check, then `prisma.permission.findUnique` and sometimes `prisma.author.findMany`. There were 17 copies of the session block and 15 of the permission lookup. Each copy was a place for the access rules to drift, which is exactly how the test page's demo bypass came to differ from the other pages.

## Why this approach

Two small modules, no framework: `lib/current-user.ts` (`getCurrentUser`, `requireCurrentUser`) and `lib/collection-access.ts` (`getPermission`, `getAuthorIds`, `requireCollectionAccess`). Actions keep their exact control flow and error strings; they just call the helpers. Pages under `/c/[cid]` call one function for the whole prologue. The chooser page passes `skipTestsolverTypeCheck` since it is the redirect target.

## What changed

- New: `lib/current-user.ts`, `lib/collection-access.ts`.
- All nine server actions across four files use `getCurrentUser()` and `getPermission()` / `getAuthorIds()`.
- Collection, problem, and chooser pages use `requireCollectionAccess()`. Add-problem, test, and invite pages use the lower-level helpers (add-problem intentionally still has no permission check; that is a later approved PR).
- `title`, `statement`, `answer`, `solution`, `spoilers` no longer take a `collection` prop they stopped reading after the demo removal.
- Tests: `test/unit/lib/current-user.test.ts` (5) and `test/integration/lib/collection-access.test.ts` (11).

## Behavior deviations (none visible to members)

- A session with no `userId` throws instead of returning an error. It cannot occur; the jwt callback always sets `sub`.
- The problem page resolves collection access before looking up the problem. A signed-in non-member visiting a nonexistent `pid` now gets `/need-permission` instead of a 404, so non-members can no longer probe which problem IDs exist. Members still get a 404.
- An anonymous visitor to a nonexistent collection gets a 404 instead of a sign-in redirect on the problem page (the collection page already behaved this way).
- Sign-in callback URLs are built with `encodeURIComponent`; identical output for every existing slug.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean (lint warnings unchanged at the 14 pre-existing type-only ones)
- `npm test`: 79 passed
- `npm run test:integration`: 98 passed
- `npm run build`: success
- Independent line-by-line review of the staged diff against the originals found no other behavior change.

## Residual risk

The chooser page now runs the authors query it does not use, one extra indexed lookup. The test page reads the full Permission row instead of one column; it is a server component so nothing extra reaches the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
