### PR TITLE
fix: log unexpected action errors server-side and return a generic message

### DIFF
--- a/app/c/[cid]/add-problem/actions.ts
+++ b/app/c/[cid]/add-problem/actions.ts
@@ -2,7 +2,7 @@
 
 import { canAddProblem } from "@/lib/permissions";
 import prisma from "@/lib/prisma";
-import { ActionResponse, error } from "@/lib/server-actions";
+import { ActionResponse, error, unexpectedError } from "@/lib/server-actions";
 import { Subject } from "@prisma/client";
 import { getCurrentUser } from "@/lib/current-user";
 import { getPermission } from "@/lib/collection-access";
@@ -127,7 +127,7 @@ export async function addProblem(
     if (isRedirectError(err)) {
       throw err;
     } else {
-      return error(String(err));
+      return unexpectedError("addProblem", err);
     }
   }
 }

--- a/app/c/[cid]/p/[pid]/actions.ts
+++ b/app/c/[cid]/p/[pid]/actions.ts
@@ -8,7 +8,11 @@ import {
   canViewCollection,
 } from "@/lib/permissions";
 import prisma from "@/lib/prisma";
-import { type ActionResponse, error } from "@/lib/server-actions";
+import {
+  type ActionResponse,
+  error,
+  unexpectedError,
+} from "@/lib/server-actions";
 import { Prisma } from "@prisma/client";
 import { getCurrentUser } from "@/lib/current-user";
 import { getAuthorIds, getPermission } from "@/lib/collection-access";
@@ -83,7 +87,7 @@ export async function likeProblem(
           // But it's still unexpected, because it shouldn't happen under normal use. So we log it
           console.error(err);
         } else {
-          return error(String(err));
+          return unexpectedError("likeProblem", err);
         }
       }
     }
@@ -91,7 +95,7 @@ export async function likeProblem(
     revalidateTag(`problem/${problem.collection.cid}_${problem.pid}`);
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("likeProblem", err);
   }
 }
 
@@ -157,7 +161,7 @@ export async function editProblem(
     revalidateTag(`problem/${problem.collection.cid}_${problem.pid}`);
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("editProblem", err);
   }
 }
 
@@ -213,7 +217,7 @@ export async function addComment(
     revalidateTag(`problem/${problemId}/comments`);
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("addComment", err);
   }
 }
 
@@ -259,7 +263,7 @@ export async function startTestsolve(
 
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("startTestsolve", err);
   }
 }
 
@@ -360,7 +364,7 @@ export async function submitTestsolve(
 
     return { ok: true, data: { correct, remaining } };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("submitTestsolve", err);
   }
 }
 
@@ -441,7 +445,7 @@ export async function giveUpTestsolve(
 
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("giveUpTestsolve", err);
   }
 }
 
@@ -484,7 +488,7 @@ export async function addSolution(
     // TODO: revalidateTag problem.id/solutions
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("addSolution", err);
   }
 }
 
@@ -540,6 +544,6 @@ export async function editSolution(
     // TODO: revalidateTag problem.id/solutions
     return { ok: true };
   } catch (err) {
-    return error(String(err));
+    return unexpectedError("editSolution", err);
   }
 }

--- a/lib/server-actions.ts
+++ b/lib/server-actions.ts
@@ -15,6 +15,22 @@ export function error(message: string): ActionResponseError {
   };
 }
 
+export const UNEXPECTED_ERROR_MESSAGE =
+  "Something went wrong. Please try again.";
+
+/**
+ * For the catch block of a server action. Logs the real error on the server
+ * (Vercel captures console output) and returns a generic message that is safe
+ * to show to the user. Raw errors can contain query text and constraint names.
+ */
+export function unexpectedError(
+  action: string,
+  err: unknown,
+): ActionResponseError {
+  console.error(`Unexpected error in ${action}:`, err);
+  return error(UNEXPECTED_ERROR_MESSAGE);
+}
+
 // Takes in an async server action, and returns a synchronous version of that action (with extra error logging). The resulting function is called from the client.
 export function wrapAction<T extends unknown[], U>(
   asyncAction: (...args: T) => Promise<ActionResponse<U>>,

--- a/test/integration/actions/testsolve.test.ts
+++ b/test/integration/actions/testsolve.test.ts
@@ -1,12 +1,12 @@
 import type { AccessLevel } from "@prisma/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   giveUpTestsolve,
   startTestsolve,
   submitTestsolve,
 } from "@/app/c/[cid]/p/[pid]/actions";
 import prisma from "@/lib/prisma";
-import { error } from "@/lib/server-actions";
+import { UNEXPECTED_ERROR_MESSAGE, error } from "@/lib/server-actions";
 import {
   createCollection,
   createPermission,
@@ -95,7 +95,15 @@ describe("startTestsolve", () => {
     await startTestsolve(problem.id);
     await startedAgo(user, problem, 5 * MINUTE);
 
-    expect((await startTestsolve(problem.id)).ok).toBe(false);
+    // The unique-key violation is logged server-side and reported generically.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(await startTestsolve(problem.id)).toEqual(
+      error(UNEXPECTED_ERROR_MESSAGE),
+    );
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
     // The original attempt (and its start time) is untouched.
     const row = await attempt(user, problem);
     expect(Date.now() - row.startedAt.getTime()).toBeGreaterThan(4 * MINUTE);

--- a/test/unit/lib/server-actions.test.ts
+++ b/test/unit/lib/server-actions.test.ts
@@ -2,13 +2,36 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type ActionResponse,
   type ActionResponseOk,
+  UNEXPECTED_ERROR_MESSAGE,
   error,
+  unexpectedError,
   wrapAction,
 } from "@/lib/server-actions";
 
 describe("error", () => {
   it("builds a failed ActionResponse carrying the message", () => {
     expect(error("nope")).toEqual({ ok: false, error: { message: "nope" } });
+  });
+});
+
+describe("unexpectedError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the real error with the action name and returns the generic message", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const boom = new Error("Unique constraint failed on the fields: (`pid`)");
+
+    expect(unexpectedError("addProblem", boom)).toEqual(
+      error(UNEXPECTED_ERROR_MESSAGE),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Unexpected error in addProblem:",
+      boom,
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

Every server action's catch block returned `error(String(err))`. That put Prisma's error text, including query shape and constraint names, into the action response, and nothing logged the error on the server, so failures never appeared in Vercel's logs.

## Why this approach

One helper, `unexpectedError(action, err)`, in the module that already owns `error()`. It logs the real error with the action name through `console.error`, which Vercel captures, and returns a fixed message. Deliberate messages such as "You do not have permission to add a problem" or "Reached maximum number of submissions (5)" are untouched; they are the ones the upcoming toast UI will show.

## What changed

- `lib/server-actions.ts`: `UNEXPECTED_ERROR_MESSAGE` and `unexpectedError()`.
- All ten `return error(String(err))` sites across `p/[pid]/actions.ts` and `add-problem/actions.ts` use it.
- Tests: unit test for the helper; the "cannot be started twice" integration test now asserts the generic message and exactly one server-side log.

## Visible behavior changes

None yet. No component displays action errors today (PR 6 adds that); this only changes what is in the response payload and adds server logs.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 80 passed
- `npm run test:integration`: 98 passed
- `npm run build`: success

## Residual risk

None identified. The only path whose message changed is the unexpected-exception path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
