### PR TITLE
feat: show server action errors as toasts and keep drafts on failed saves

### DIFF
--- a/app/c/[cid]/p/[pid]/archive-toggle.tsx
+++ b/app/c/[cid]/p/[pid]/archive-toggle.tsx
@@ -12,7 +12,10 @@ export default function ArchiveToggle(props: Props) {
   const handleChange = () => {
     const newIsArchived = !isArchived;
     setArchived(newIsArchived);
-    wrapAction(editProblem)(problem.id, { isArchived: newIsArchived });
+    wrapAction(editProblem, undefined, () => setArchived(!newIsArchived))(
+      problem.id,
+      { isArchived: newIsArchived },
+    );
   };
 
   return (

--- a/app/c/[cid]/p/[pid]/editable-answer.tsx
+++ b/app/c/[cid]/p/[pid]/editable-answer.tsx
@@ -3,7 +3,7 @@
 import ClickToEdit from "@/components/click-to-edit";
 import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
-import { wrapAction } from "@/lib/server-actions";
+import { runAction } from "@/lib/server-actions";
 
 export default function EditableAnswer({
   problem,
@@ -12,8 +12,9 @@ export default function EditableAnswer({
   problem: Problem;
   label: React.ReactNode;
 }) {
-  const saveAnswer = (text: string) => {
-    wrapAction(editProblem)(problem.id, { answer: text });
+  const saveAnswer = async (text: string) => {
+    const resp = await runAction(editProblem)(problem.id, { answer: text });
+    return resp?.ok ?? false;
   };
 
   if (problem.answer === null) {

--- a/app/c/[cid]/p/[pid]/editable-solution.tsx
+++ b/app/c/[cid]/p/[pid]/editable-solution.tsx
@@ -4,7 +4,7 @@ import ClickToEdit from "@/components/click-to-edit";
 import type { SolutionProps } from "./types";
 import { useRouter } from "next/navigation";
 import { editSolution } from "./actions";
-import { wrapAction } from "@/lib/server-actions";
+import { runAction } from "@/lib/server-actions";
 
 export default function EditableSolution({
   solution,
@@ -16,11 +16,13 @@ export default function EditableSolution({
   const router = useRouter();
 
   // TODO: useOptimistic instead of refreshing
-  const tryEditSolution = wrapAction(editSolution, () => router.refresh());
-
-  // const authorName = solution.authors[0].displayName;
-  const saveSolution = (text: string) => {
-    tryEditSolution(solution.id, text);
+  const saveSolution = async (text: string) => {
+    const resp = await runAction(editSolution)(solution.id, text);
+    const saved = resp?.ok ?? false;
+    if (saved) {
+      router.refresh();
+    }
+    return saved;
   };
 
   return (

--- a/app/c/[cid]/p/[pid]/editable-statement.tsx
+++ b/app/c/[cid]/p/[pid]/editable-statement.tsx
@@ -3,11 +3,12 @@
 import ClickToEdit from "@/components/click-to-edit";
 import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
-import { wrapAction } from "@/lib/server-actions";
+import { runAction } from "@/lib/server-actions";
 
 export default function EditableStatement({ problem }: { problem: Problem }) {
-  const saveStatement = (text: string) => {
-    wrapAction(editProblem)(problem.id, { statement: text });
+  const saveStatement = async (text: string) => {
+    const resp = await runAction(editProblem)(problem.id, { statement: text });
+    return resp?.ok ?? false;
   };
 
   return (

--- a/app/c/[cid]/p/[pid]/editable-title.tsx
+++ b/app/c/[cid]/p/[pid]/editable-title.tsx
@@ -3,11 +3,12 @@
 import ClickToEdit from "@/components/click-to-edit";
 import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
-import { wrapAction } from "@/lib/server-actions";
+import { runAction } from "@/lib/server-actions";
 
 export default function EditableTitle({ problem }: { problem: Problem }) {
-  const saveTitle = (text: string) => {
-    wrapAction(editProblem)(problem.id, { title: text });
+  const saveTitle = async (text: string) => {
+    const resp = await runAction(editProblem)(problem.id, { title: text });
+    return resp?.ok ?? false;
   };
 
   return (

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto my-24 w-128 max-w-full px-8 text-slate-800">
+      <h1 className="mb-8 text-3xl">Something went wrong</h1>
+      <p className="mb-8 text-xl">
+        An unexpected error occurred while loading this page.
+      </p>
+      <button
+        onClick={reset}
+        className="rounded bg-violet-500 px-4 py-2 font-bold text-white hover:bg-violet-600"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Toaster from "@/components/toaster";
 
 import "../styles/globals.css";
 import "katex/dist/katex.min.css";
@@ -28,7 +29,10 @@ export default function RootLayout({
       <link rel="icon" href="/favicon.ico" />
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css" />
       */}
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import Sidebar from "@/components/sidebar";
+
+export default function NotFoundPage() {
+  return (
+    <Sidebar>
+      <div className="mx-auto my-24 w-128 max-w-full px-8">
+        <h1 className="mb-8 text-3xl">Page not found</h1>
+        <p className="mb-8 text-xl">
+          This page does not exist, or the problem or collection was removed.
+        </p>
+        <Link
+          href="/"
+          prefetch={true}
+          className="rounded bg-violet-500 px-4 py-2 font-bold text-white hover:bg-violet-600"
+        >
+          Back to home
+        </Link>
+      </div>
+    </Sidebar>
+  );
+}

--- a/components/click-to-edit.tsx
+++ b/components/click-to-edit.tsx
@@ -21,32 +21,55 @@ export default function ClickToEdit({
   initialText: string;
   placeholder?: string;
   autosave: boolean;
-  onSave: (text: string) => void;
+  /**
+   * Called with the new text when the user saves. A save that persists
+   * somewhere should return whether it succeeded; on `false` the editor
+   * reopens with the user's text so nothing is lost. Synchronous savers
+   * (local state) can return nothing.
+   */
+  onSave: (text: string) => void | Promise<boolean>;
   required: boolean;
 }) {
   const [isEditing, setEditing] = useState(initialText === "");
   const [savedText, setSavedText] = useState(initialText);
+  // Text to put back into the editor after a failed save.
+  const [draft, setDraft] = useState<string | null>(null);
 
   const handleSave = (text: string) => {
+    const previous = savedText;
     setSavedText(text);
-    onSave(text);
+    setDraft(null);
     setEditing(false);
+    const result = onSave(text);
+    if (result instanceof Promise) {
+      result
+        .then((saved) => {
+          if (!saved) {
+            setSavedText(previous);
+            setDraft(text);
+            setEditing(true);
+          }
+        })
+        .catch((err) => console.error(err));
+    }
   };
 
   const handleReset = () => {
+    setDraft(null);
     if (savedText !== "") {
       setEditing(false);
     }
   };
 
   if (isEditing) {
+    const editorText = draft ?? savedText;
     return (
       <div>
         {label}
         {type === "input" ? (
           <ClickToEditInput
             name={name}
-            savedText={savedText}
+            savedText={editorText}
             placeholder={placeholder}
             onSave={handleSave}
             onReset={handleReset}
@@ -55,7 +78,7 @@ export default function ClickToEdit({
         ) : (
           <ClickToEditTextarea
             name={name}
-            savedText={savedText}
+            savedText={editorText}
             placeholder={placeholder}
             autosave={autosave}
             onSave={handleSave}

--- a/components/likes.tsx
+++ b/components/likes.tsx
@@ -24,17 +24,18 @@ export default function Likes({
     problem.likes.some((like) => like.userId === userId),
   );
 
-  const action = wrapAction(likeProblem);
-
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
-    if (liked) {
-      setNumLikes(numLikes - 1);
-    } else {
-      setNumLikes(numLikes + 1);
-    }
-    setLiked(!liked);
-    action(problem.id, !liked);
+    const wasLiked = liked;
+    const previousNumLikes = numLikes;
+    setNumLikes(wasLiked ? numLikes - 1 : numLikes + 1);
+    setLiked(!wasLiked);
+    // Undo the optimistic update if the server rejects it.
+    const revert = () => {
+      setLiked(wasLiked);
+      setNumLikes(previousNumLikes);
+    };
+    wrapAction(likeProblem, undefined, revert)(problem.id, !wasLiked);
   };
 
   return (

--- a/components/toaster.tsx
+++ b/components/toaster.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCircleExclamation,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { subscribeToErrors } from "@/lib/toast";
+
+const DISMISS_AFTER_MILLIS = 8_000;
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+let nextId = 1;
+
+/** Renders error toasts sent through notifyError(). Mount once, in the root layout. */
+export default function Toaster() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = (id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  };
+
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const unsubscribe = subscribeToErrors((message) => {
+      const id = nextId++;
+      setToasts((current) => [...current, { id, message }]);
+      timers.push(setTimeout(() => dismiss(id), DISMISS_AFTER_MILLIS));
+    });
+    return () => {
+      unsubscribe();
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed bottom-6 right-6 z-50 flex w-80 max-w-[calc(100vw-3rem)] flex-col gap-3"
+      aria-live="assertive"
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900 shadow-lg shadow-red-500/10"
+        >
+          <FontAwesomeIcon
+            icon={faCircleExclamation}
+            className="mt-0.5 text-red-500"
+          />
+          <p className="flex-grow">{toast.message}</p>
+          <button
+            type="button"
+            onClick={() => dismiss(toast.id)}
+            aria-label="Dismiss"
+            className="text-red-400 hover:text-red-600"
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/server-actions.ts
+++ b/lib/server-actions.ts
@@ -1,3 +1,5 @@
+import { notifyError } from "@/lib/toast";
+
 export type ActionResponseOk<T = undefined> = T extends undefined
   ? { ok: true }
   : { ok: true; data: T };
@@ -31,29 +33,58 @@ export function unexpectedError(
   return error(UNEXPECTED_ERROR_MESSAGE);
 }
 
-// Takes in an async server action, and returns a synchronous version of that action (with extra error logging). The resulting function is called from the client.
+/**
+ * Calls a server action from the client and shows its error, if any, as a
+ * toast. Resolves with the response so the caller can react to failure (for
+ * example by reopening an editor). Resolves with `undefined` after a redirect:
+ * Next.js resolves redirecting actions with no value on the client
+ * (https://github.com/vercel/next.js/issues/50659), and the redirect still
+ * happens.
+ */
+export function runAction<T extends unknown[], U>(
+  asyncAction: (...args: T) => Promise<ActionResponse<U>>,
+): (...args: T) => Promise<ActionResponse<U> | undefined> {
+  return async (...args: T) => {
+    let resp: ActionResponse<U> | undefined;
+    try {
+      resp = await asyncAction(...args);
+    } catch (err) {
+      console.error(err);
+      notifyError(UNEXPECTED_ERROR_MESSAGE);
+      return error(UNEXPECTED_ERROR_MESSAGE);
+    }
+    if (resp === undefined) {
+      console.warn("Response is undefined after a redirect");
+      return undefined;
+    }
+    if (!resp.ok) {
+      console.error("Server action returned error: ", resp.error.message);
+      notifyError(resp.error.message);
+    }
+    return resp;
+  };
+}
+
+// Takes in an async server action, and returns a synchronous version of that action. The resulting function is called from the client. Errors are shown as a toast; pass onError to also undo optimistic UI.
 export function wrapAction<T extends unknown[], U>(
   asyncAction: (...args: T) => Promise<ActionResponse<U>>,
   onSuccess?: (resp: ActionResponseOk<U>) => void,
+  onError?: (resp: ActionResponseError) => void,
 ): (...args: T) => void {
+  const run = runAction(asyncAction);
   const syncAction = (...args: T) => {
-    (async () => {
-      const resp = await asyncAction(...args);
-      if (resp === undefined) {
-        console.warn("Response is undefined after a redirect");
-        // This is a bug in Next.js
-        // See https://github.com/vercel/next.js/issues/50659
-        // The redirect still works, so there's no need to do anything else
-        return;
-      }
-      if (resp.ok) {
-        if (onSuccess) {
-          onSuccess(resp);
+    run(...args)
+      .then((resp) => {
+        if (resp === undefined) {
+          return;
         }
-      } else {
-        console.error("Server action returned error: ", resp.error.message);
-      }
-    })().catch((err) => console.error(err));
+        if (resp.ok) {
+          onSuccess?.(resp);
+        } else {
+          onError?.(resp);
+        }
+      })
+      .catch((err) => console.error(err));
   };
   return syncAction;
 }

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,23 @@
+// A minimal error-toast channel. Anything on the client can call
+// notifyError(); the <Toaster /> in the root layout subscribes and renders.
+// Kept free of React so lib/server-actions.ts can import it.
+
+export type ToastListener = (message: string) => void;
+
+let listener: ToastListener | null = null;
+
+export function notifyError(message: string): void {
+  if (listener !== null) {
+    listener(message);
+  }
+}
+
+/** Register the single renderer. Returns an unsubscribe function. */
+export function subscribeToErrors(next: ToastListener): () => void {
+  listener = next;
+  return () => {
+    if (listener === next) {
+      listener = null;
+    }
+  };
+}

--- a/test/unit/components/click-to-edit.test.tsx
+++ b/test/unit/components/click-to-edit.test.tsx
@@ -1,0 +1,138 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ClickToEdit from "@/components/click-to-edit";
+
+function hiddenValue(container: HTMLElement): string | null {
+  const input = container.querySelector<HTMLInputElement>(
+    'input[type="hidden"][name="title"]',
+  );
+  return input?.value ?? null;
+}
+
+describe("ClickToEdit", () => {
+  it("starts in display mode with the saved text and a hidden form field", () => {
+    const { container } = render(
+      <ClickToEdit
+        type="input"
+        name="title"
+        initialText="Before"
+        autosave={true}
+        onSave={() => {}}
+        required={false}
+      />,
+    );
+
+    expect(screen.getByText("Before")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(hiddenValue(container)).toBe("Before");
+  });
+
+  it("saves optimistically for a synchronous saver", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const { container } = render(
+      <ClickToEdit
+        type="input"
+        name="title"
+        initialText="Before"
+        autosave={true}
+        onSave={onSave}
+        required={false}
+      />,
+    );
+
+    await user.click(screen.getByText("Before"));
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "After{Enter}");
+
+    expect(onSave).toHaveBeenCalledWith("After");
+    expect(screen.getByText("After")).toBeInTheDocument();
+    expect(hiddenValue(container)).toBe("After");
+  });
+
+  it("keeps the new text when an async save succeeds", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <ClickToEdit
+        type="input"
+        name="title"
+        initialText="Before"
+        autosave={true}
+        onSave={onSave}
+        required={false}
+      />,
+    );
+
+    await user.click(screen.getByText("Before"));
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "After{Enter}");
+    await act(async () => {});
+
+    expect(screen.getByText("After")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("reopens the editor with the draft, and restores the old value, when a save fails", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(false);
+    const { container } = render(
+      <ClickToEdit
+        type="input"
+        name="title"
+        initialText="Before"
+        autosave={true}
+        onSave={onSave}
+        required={false}
+      />,
+    );
+
+    await user.click(screen.getByText("Before"));
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "After{Enter}");
+    await act(async () => {});
+
+    // Editor is open again, holding the user's draft, so nothing is lost.
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("After");
+    expect(hiddenValue(container)).toBeNull();
+
+    // Escape discards the draft and shows the last saved value.
+    await user.keyboard("{Escape}");
+    expect(screen.getByText("Before")).toBeInTheDocument();
+    expect(hiddenValue(container)).toBe("Before");
+  });
+
+  it("lets the user retry after a failed save", async () => {
+    const user = userEvent.setup();
+    const onSave = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    render(
+      <ClickToEdit
+        type="input"
+        name="title"
+        initialText="Before"
+        autosave={true}
+        onSave={onSave}
+        required={false}
+      />,
+    );
+
+    await user.click(screen.getByText("Before"));
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "After{Enter}");
+    await act(async () => {});
+    expect(screen.getByRole("textbox")).toHaveValue("After");
+
+    await user.type(screen.getByRole("textbox"), "{Enter}");
+    await act(async () => {});
+
+    expect(onSave).toHaveBeenNthCalledWith(2, "After");
+    expect(screen.getByText("After")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/test/unit/components/toaster.test.tsx
+++ b/test/unit/components/toaster.test.tsx
@@ -1,0 +1,62 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Toaster from "@/components/toaster";
+import { notifyError } from "@/lib/toast";
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing until an error is sent", () => {
+    const { container } = render(<Toaster />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows each error as an alert", () => {
+    render(<Toaster />);
+
+    act(() => {
+      notifyError("You do not have permission to edit this problem");
+      notifyError("Invite has expired");
+    });
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]).toHaveTextContent(
+      "You do not have permission to edit this problem",
+    );
+    expect(alerts[1]).toHaveTextContent("Invite has expired");
+  });
+
+  it("dismisses a toast when its close button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Toaster />);
+    act(() => {
+      notifyError("nope");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("dismisses a toast on its own after a few seconds", () => {
+    render(<Toaster />);
+    act(() => {
+      notifyError("nope");
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(8_000);
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/test/unit/lib/server-actions.test.ts
+++ b/test/unit/lib/server-actions.test.ts
@@ -4,9 +4,66 @@ import {
   type ActionResponseOk,
   UNEXPECTED_ERROR_MESSAGE,
   error,
+  runAction,
   unexpectedError,
   wrapAction,
 } from "@/lib/server-actions";
+import { subscribeToErrors } from "@/lib/toast";
+
+function captureToasts() {
+  const toasts: string[] = [];
+  const unsubscribe = subscribeToErrors((message) => toasts.push(message));
+  return { toasts, unsubscribe };
+}
+
+describe("runAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves with the response and shows nothing on success", async () => {
+    const { toasts, unsubscribe } = captureToasts();
+    const action = (): Promise<ActionResponse<{ n: number }>> =>
+      Promise.resolve({ ok: true, data: { n: 7 } });
+
+    expect(await runAction(action)()).toEqual({ ok: true, data: { n: 7 } });
+    expect(toasts).toEqual([]);
+    unsubscribe();
+  });
+
+  it("shows the error message as a toast and still resolves with the response", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { toasts, unsubscribe } = captureToasts();
+    const action = (): Promise<ActionResponse> =>
+      Promise.resolve(error("Not signed in"));
+
+    expect(await runAction(action)()).toEqual(error("Not signed in"));
+    expect(toasts).toEqual(["Not signed in"]);
+    unsubscribe();
+  });
+
+  it("turns a rejected action into the generic error and toasts it", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { toasts, unsubscribe } = captureToasts();
+    const action = (): Promise<ActionResponse> =>
+      Promise.reject(new Error("boom"));
+
+    expect(await runAction(action)()).toEqual(error(UNEXPECTED_ERROR_MESSAGE));
+    expect(toasts).toEqual([UNEXPECTED_ERROR_MESSAGE]);
+    unsubscribe();
+  });
+
+  it("resolves with undefined after a redirect without toasting", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { toasts, unsubscribe } = captureToasts();
+    const action = () =>
+      Promise.resolve(undefined) as unknown as Promise<ActionResponse>;
+
+    expect(await runAction(action)()).toBeUndefined();
+    expect(toasts).toEqual([]);
+    unsubscribe();
+  });
+});
 
 describe("error", () => {
   it("builds a failed ActionResponse carrying the message", () => {
@@ -67,22 +124,27 @@ describe("wrapAction", () => {
     expect(onSuccess).toHaveBeenCalledWith({ ok: true, data: { n: 7 } });
   });
 
-  it("logs an error response and does not call onSuccess", async () => {
+  it("logs an error response, toasts it, calls onError and not onSuccess", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    const { toasts, unsubscribe } = captureToasts();
     const action = (): Promise<ActionResponse> =>
       Promise.resolve(error("Not signed in"));
     const onSuccess = vi.fn();
+    const onError = vi.fn();
 
-    wrapAction(action, onSuccess)();
+    wrapAction(action, onSuccess, onError)();
     await flush();
 
     expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(error("Not signed in"));
+    expect(toasts).toEqual(["Not signed in"]);
     expect(consoleError).toHaveBeenCalledWith(
       "Server action returned error: ",
       "Not signed in",
     );
+    unsubscribe();
   });
 
   it("catches a rejected action instead of leaving an unhandled rejection", async () => {

--- a/test/unit/lib/toast.test.ts
+++ b/test/unit/lib/toast.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { notifyError, subscribeToErrors } from "@/lib/toast";
+
+describe("toast channel", () => {
+  it("delivers messages to the subscribed listener", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToErrors(listener);
+
+    notifyError("nope");
+
+    expect(listener).toHaveBeenCalledWith("nope");
+    unsubscribe();
+  });
+
+  it("drops messages once unsubscribed", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToErrors(listener);
+    unsubscribe();
+
+    notifyError("nope");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale unsubscribe remove a newer listener", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = subscribeToErrors(first);
+    const unsubscribeSecond = subscribeToErrors(second);
+    unsubscribeFirst();
+
+    notifyError("nope");
+
+    expect(second).toHaveBeenCalledWith("nope");
+    expect(first).not.toHaveBeenCalled();
+    unsubscribeSecond();
+  });
+});


### PR DESCRIPTION
## Problem

No component displayed a server action's error. `wrapAction` logged it to the browser console and did nothing else. A rejected edit, comment, like, or testsolve submission looked like nothing happened, and the optimistic UI in `ClickToEdit`, `Likes`, and `ArchiveToggle` kept showing a change that had not been saved. A user editing a title without permission saw their new title until they next reloaded.

## Why this approach

- A module-level `notifyError()` channel in `lib/toast.ts` with one subscriber, the `Toaster` in the root layout. No context provider, no dependency. `wrapAction` calls it, so every existing call site gets toasts with no changes.
- `runAction()` is the promise-returning sibling of `wrapAction()` for the few callers that need the outcome. `wrapAction` is now built on it and takes an optional `onError`.
- For `ClickToEdit`, the approved design: on a failed save the editor reopens holding the user's draft while the previous value is restored as the saved text. Nothing is lost, nothing lies. Escape discards the draft.
- `Likes` and `ArchiveToggle` simply revert, since they have no draft.

## What changed

- New `lib/toast.ts`, `components/toaster.tsx`, `app/error.tsx`, `app/not-found.tsx`.
- `lib/server-actions.ts`: `runAction`, `wrapAction(action, onSuccess?, onError?)`.
- `components/click-to-edit.tsx`: `onSave: (text) => void | Promise<boolean>` with reopen-on-failure.
- `editable-title/statement/answer/solution.tsx` return the save result through `runAction`.
- `components/likes.tsx`, `archive-toggle.tsx` revert on error.
- `app/layout.tsx` mounts `<Toaster />`.
- Tests: `toast.test.ts` (3), `runAction` and `wrapAction onError` (5 new), `click-to-edit.test.tsx` (5), `toaster.test.tsx` (4).

## Visible behavior changes (approved)

- Failed actions show a red toast at the bottom right with the action's message, auto-dismissing after 8 seconds.
- A failed inline edit reopens the editor with the draft instead of silently showing unsaved text.
- A failed like or archive toggle snaps back.
- Crashes and unknown routes render styled pages instead of Next.js defaults.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 96 passed
- `npm run test:integration`: 98 passed
- `npm run build`: success
- Dev server smoke test against the throwaway test DB: `/` 200, `/nonexistent-page` and `/c/nope` render the new 404 page, no runtime errors in the server log.

## Residual risk

The toast only ever shows messages the server chose to return; after PR #161 the unexpected-exception path returns a fixed generic message, so no Prisma text can reach it. Redirecting actions (add problem, accept invite, choose testsolver type) resolve with `undefined` on the client as before and show nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
