### PR TITLE
fix: hide add problem from members who cannot submit, and check before creating an author

### DIFF
--- a/app/c/[cid]/add-problem/page.tsx
+++ b/app/c/[cid]/add-problem/page.tsx
@@ -1,9 +1,10 @@
 import ProblemForm from "./problem-form";
 import prisma from "@/lib/prisma";
 import { Session } from "next-auth";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { requireCurrentUser, type CurrentUser } from "@/lib/current-user";
-import { getAuthorIds } from "@/lib/collection-access";
+import { getAuthorIds, getPermission } from "@/lib/collection-access";
+import { canAddProblem } from "@/lib/permissions";
 
 interface Params {
   cid: string;
@@ -59,7 +60,16 @@ export default async function AddProblemPage({ params }: { params: Params }) {
 
   // TODO: select only needed fields of collection
   const collection = await getCollection(cid);
-  // TODO: ViewOnly should see a different page explaining why they can't submit
+
+  // Check before creating an Author row, so visiting the URL without the
+  // right to submit leaves no trace. SubmitOnly members may add problems
+  // even though they cannot view the collection, so this is deliberately
+  // not requireCollectionAccess().
+  const permission = await getPermission(user.userId, collection.id);
+  if (!canAddProblem(permission)) {
+    redirect("/need-permission");
+  }
+
   const authorId = await getOrCreateAuthor(user, collection.id);
 
   return <ProblemForm collection={collection} authorId={authorId} />;

--- a/components/problem-list-sidebar.tsx
+++ b/components/problem-list-sidebar.tsx
@@ -3,6 +3,7 @@ import { ProblemListSearch } from "./problem-list-search";
 import { ProblemListFilter } from "./problem-list-filter";
 import { Filter } from "@/lib/filter";
 import { Permission, Collection } from "@prisma/client";
+import { canAddProblem } from "@/lib/permissions";
 
 interface ProblemListSidebarProps {
   collection: Collection;
@@ -18,13 +19,15 @@ export function ProblemListSidebar({
   return (
     <>
       <div className="mb-2 flex flex-col gap-x-8 gap-y-6 sm:flex-row xl:flex-col">
-        <Link
-          href={`/c/${collection.cid}/add-problem`}
-          prefetch={true}
-          className="soft-shadow-xl inline-block w-full rounded-xl bg-violet-500 px-10 py-3 text-center text-base font-bold text-slate-50 hover:bg-violet-600 sm:max-w-56 xl:max-w-full"
-        >
-          Add Problem
-        </Link>
+        {canAddProblem(permission) && (
+          <Link
+            href={`/c/${collection.cid}/add-problem`}
+            prefetch={true}
+            className="soft-shadow-xl inline-block w-full rounded-xl bg-violet-500 px-10 py-3 text-center text-base font-bold text-slate-50 hover:bg-violet-600 sm:max-w-56 xl:max-w-full"
+          >
+            Add Problem
+          </Link>
+        )}
         <ProblemListSearch filter={filter} />
       </div>
       <ProblemListFilter

--- a/test/integration/pages/add-problem.test.ts
+++ b/test/integration/pages/add-problem.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import AddProblemPage from "@/app/c/[cid]/add-problem/page";
+import prisma from "@/lib/prisma";
+import {
+  createAuthor,
+  createCollection,
+  createPermission,
+  createUser,
+} from "../factories";
+import { expectNotFound, expectRedirect } from "../navigation";
+import { signInAs, signOut } from "../session";
+
+function render(cid: string) {
+  return AddProblemPage({ params: { cid } });
+}
+
+describe("add-problem page", () => {
+  it("sends a signed-out visitor to sign in, returning here afterwards", async () => {
+    const collection = await createCollection();
+    signOut();
+
+    await expectRedirect(
+      render(collection.cid),
+      `/api/auth/signin?callbackUrl=%2Fc%2F${collection.cid}%2Fadd-problem`,
+    );
+  });
+
+  it("404s for an unknown collection", async () => {
+    signInAs(await createUser());
+    await expectNotFound(render("nope"));
+  });
+
+  it("redirects a ViewOnly member without creating an author", async () => {
+    const collection = await createCollection();
+    const user = await createUser();
+    await createPermission(user, collection, "ViewOnly");
+    signInAs(user);
+
+    await expectRedirect(render(collection.cid), "/need-permission");
+    expect(await prisma.author.count()).toBe(0);
+  });
+
+  it("redirects a user with no permission row without creating an author", async () => {
+    const collection = await createCollection();
+    signInAs(await createUser());
+
+    await expectRedirect(render(collection.cid), "/need-permission");
+    expect(await prisma.author.count()).toBe(0);
+  });
+
+  it.each(["Admin", "TeamMember", "SubmitOnly"] as const)(
+    "renders the form for a %s member, creating their author on first visit",
+    async (level) => {
+      const collection = await createCollection();
+      const user = await createUser({ name: "Ada Lovelace" });
+      await createPermission(user, collection, level);
+      signInAs(user);
+
+      const page = await render(collection.cid);
+
+      expect(page).toBeTruthy();
+      const authors = await prisma.author.findMany({
+        where: { userId: user.id, collectionId: collection.id },
+      });
+      expect(authors).toHaveLength(1);
+    },
+  );
+
+  it("reuses an existing author instead of creating another", async () => {
+    const collection = await createCollection();
+    const user = await createUser();
+    await createPermission(user, collection, "TeamMember");
+    const existing = await createAuthor(collection, { userId: user.id });
+    signInAs(user);
+
+    await render(collection.cid);
+
+    const authors = await prisma.author.findMany({
+      where: { userId: user.id },
+    });
+    expect(authors.map((a) => a.id)).toEqual([existing.id]);
+  });
+});

--- a/test/unit/components/problem-list-sidebar.test.tsx
+++ b/test/unit/components/problem-list-sidebar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import type { AccessLevel, Collection, Permission } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { ProblemListSidebar } from "@/components/problem-list-sidebar";
+
+// The search and filter children read the router; they are not under test here.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/c/test",
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+const collection = {
+  id: 1,
+  cid: "test",
+  name: "Test",
+  requireTestsolve: false,
+} as Collection;
+
+function permission(accessLevel: AccessLevel): Permission {
+  return {
+    id: 1,
+    userId: "u",
+    collectionId: 1,
+    accessLevel,
+    createdAt: new Date(),
+    testsolverType: null,
+    seriousTestsolverStartedAt: null,
+  };
+}
+
+const filter = {
+  subjects: [],
+  search: "",
+  archived: false,
+  page: 1,
+  unsolvedOnly: false,
+};
+
+describe("ProblemListSidebar", () => {
+  it.each(["Admin", "TeamMember"] as const)(
+    "shows the Add Problem link to a %s",
+    (level) => {
+      render(
+        <ProblemListSidebar
+          collection={collection}
+          permission={permission(level)}
+          filter={filter}
+        />,
+      );
+      expect(screen.getByRole("link", { name: "Add Problem" })).toHaveAttribute(
+        "href",
+        "/c/test/add-problem",
+      );
+    },
+  );
+
+  it("hides the Add Problem link from a ViewOnly member", () => {
+    render(
+      <ProblemListSidebar
+        collection={collection}
+        permission={permission("ViewOnly")}
+        filter={filter}
+      />,
+    );
+    expect(
+      screen.queryByRole("link", { name: "Add Problem" }),
+    ).not.toBeInTheDocument();
+    // The rest of the sidebar is still there.
+    expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

`components/problem-list-sidebar.tsx` rendered the Add Problem button for every member, and `app/c/[cid]/add-problem/page.tsx` created an `Author` row for any signed-in visitor before checking any permission. A ViewOnly member could click through, fill in the form, and get a silent failure on submit, leaving behind an Author row they never used.

## Why this approach

Both places use the existing `canAddProblem()` predicate, so the button and the page cannot disagree. The page deliberately calls `getPermission()` rather than `requireCollectionAccess()`: SubmitOnly members may add problems even though they cannot view the collection, and that access is preserved.

## What changed

- `problem-list-sidebar.tsx`: Add Problem link rendered only when `canAddProblem(permission)`.
- `add-problem/page.tsx`: permission check between the collection lookup and `getOrCreateAuthor`, redirecting to `/need-permission`.
- New tests: `test/integration/pages/add-problem.test.ts` (7 cases: sign-in redirect with callback, 404, ViewOnly and no-permission redirect with no Author created, Admin/TeamMember/SubmitOnly render and create an Author once, existing Author reused) and `test/unit/components/problem-list-sidebar.test.tsx` (3).

## Visible behavior changes (approved)

- ViewOnly members no longer see the Add Problem button, and typing the URL sends them to the need-permission page instead of a form that cannot submit.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 99 passed
- `npm run test:integration`: 106 passed
- `npm run build`: success

## Residual risk

None identified. Admin, TeamMember, and SubmitOnly behavior is unchanged and covered by the new page tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
