### PR TITLE
refactor: server-render the problem page and keep locked content off the client

### DIFF
--- a/app/c/[cid]/p/[pid]/add-solution.tsx
+++ b/app/c/[cid]/p/[pid]/add-solution.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useRef, useEffect } from "react";
 import type { KeyboardEvent } from "react";
-import { ProblemProps } from "./types";
 import { addSolution } from "./actions";
 import { wrapAction } from "@/lib/server-actions";
 
 export default function AddSolution({
-  problem,
+  problemId,
   authorId,
 }: {
-  problem: ProblemProps;
+  problemId: number;
   authorId: number;
 }) {
   const [isEditing, setEditing] = useState(false);
@@ -42,7 +41,7 @@ export default function AddSolution({
   }, [text]);
 
   const handleSubmit = () => {
-    wrapAction(addSolution)(problem.id, text, authorId);
+    wrapAction(addSolution)(problemId, text, authorId);
   };
 
   const handleDiscard = () => {

--- a/app/c/[cid]/p/[pid]/answer.tsx
+++ b/app/c/[cid]/p/[pid]/answer.tsx
@@ -10,7 +10,12 @@ export default function Answer(props: Props) {
   const label = <Label text="ANSWER" />;
 
   if (canEdit) {
-    return <EditableAnswer problem={problem} label={label} />;
+    return (
+      <EditableAnswer
+        problem={{ id: problem.id, answer: problem.answer }}
+        label={label}
+      />
+    );
   } else {
     return (
       <>

--- a/app/c/[cid]/p/[pid]/archive-toggle.tsx
+++ b/app/c/[cid]/p/[pid]/archive-toggle.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-import type { Props } from "./types";
 import { useState } from "react";
 import { editProblem } from "./actions";
 import { wrapAction } from "@/lib/server-actions";
 
-export default function ArchiveToggle(props: Props) {
-  const { problem } = props;
-  const [isArchived, setArchived] = useState(problem.isArchived);
+export default function ArchiveToggle({
+  problemId,
+  isArchived: initialIsArchived,
+}: {
+  problemId: number;
+  isArchived: boolean;
+}) {
+  const [isArchived, setArchived] = useState(initialIsArchived);
 
   const handleChange = () => {
     const newIsArchived = !isArchived;
     setArchived(newIsArchived);
     wrapAction(editProblem, undefined, () => setArchived(!newIsArchived))(
-      problem.id,
+      problemId,
       { isArchived: newIsArchived },
     );
   };

--- a/app/c/[cid]/p/[pid]/comments.tsx
+++ b/app/c/[cid]/p/[pid]/comments.tsx
@@ -2,34 +2,25 @@
 
 import { useState } from "react";
 import Comment from "./comment";
-import type { Props } from "./types";
+import type { CommentProps } from "./types";
 import SubmitButton from "@/components/submit-button";
 import { addComment } from "./actions";
 import { wrapAction } from "@/lib/server-actions";
 
-export default function Comments(props: Props) {
+export default function Comments({
+  problemId,
+  comments,
+}: {
+  problemId: number;
+  comments: CommentProps[];
+}) {
   const [text, setText] = useState("");
-
-  const { problem } = props;
-  const allComments = problem.comments;
 
   const tryAddComment = wrapAction(addComment, () => setText(""));
 
   const action = (formData: FormData) => {
-    tryAddComment(problem.id, formData);
+    tryAddComment(problemId, formData);
   };
-
-  const comments = (
-    <div>
-      <ul>
-        {allComments.map((comment) => (
-          <li key={comment.id}>
-            <Comment comment={comment} />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
 
   return (
     <div>
@@ -56,7 +47,15 @@ export default function Comments(props: Props) {
         </div>
         <SubmitButton size="sm">Post comment</SubmitButton>
       </form>
-      {comments}
+      <div>
+        <ul>
+          {comments.map((comment) => (
+            <li key={comment.id}>
+              <Comment comment={comment} />
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/app/c/[cid]/p/[pid]/editable-answer.tsx
+++ b/app/c/[cid]/p/[pid]/editable-answer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import ClickToEdit from "@/components/click-to-edit";
-import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
 import { runAction } from "@/lib/server-actions";
 
@@ -9,7 +8,7 @@ export default function EditableAnswer({
   problem,
   label,
 }: {
-  problem: Problem;
+  problem: { id: number; answer: string | null };
   label: React.ReactNode;
 }) {
   const saveAnswer = async (text: string) => {

--- a/app/c/[cid]/p/[pid]/editable-statement.tsx
+++ b/app/c/[cid]/p/[pid]/editable-statement.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import ClickToEdit from "@/components/click-to-edit";
-import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
 import { runAction } from "@/lib/server-actions";
 
-export default function EditableStatement({ problem }: { problem: Problem }) {
+export default function EditableStatement({
+  problem,
+}: {
+  problem: { id: number; statement: string };
+}) {
   const saveStatement = async (text: string) => {
     const resp = await runAction(editProblem)(problem.id, { statement: text });
     return resp?.ok ?? false;

--- a/app/c/[cid]/p/[pid]/editable-title.tsx
+++ b/app/c/[cid]/p/[pid]/editable-title.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import ClickToEdit from "@/components/click-to-edit";
-import type { Problem } from "@prisma/client";
 import { editProblem } from "./actions";
 import { runAction } from "@/lib/server-actions";
 
-export default function EditableTitle({ problem }: { problem: Problem }) {
+export default function EditableTitle({
+  problem,
+}: {
+  problem: { id: number; title: string };
+}) {
   const saveTitle = async (text: string) => {
     const resp = await runAction(editProblem)(problem.id, { title: text });
     return resp?.ok ?? false;

--- a/app/c/[cid]/p/[pid]/locked-page.tsx
+++ b/app/c/[cid]/p/[pid]/locked-page.tsx
@@ -3,17 +3,16 @@
 import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/navigation";
-import { ProblemProps } from "./types";
 import SubmitButton from "@/components/submit-button";
 import { startTestsolve } from "./actions";
 import { wrapAction } from "@/lib/server-actions";
 
 export default function LockedPage({
-  problem,
+  problemId,
   time,
   unsolved,
 }: {
-  problem: ProblemProps;
+  problemId: number;
   time: string;
   unsolved: boolean;
 }) {
@@ -47,7 +46,7 @@ export default function LockedPage({
         )}
         <p>Best of luck!</p>
       </div>
-      <form action={() => tryStartTestsolving(problem.id)}>
+      <form action={() => tryStartTestsolving(problemId)}>
         <SubmitButton className="w-full">Start testsolving</SubmitButton>
       </form>
     </div>

--- a/app/c/[cid]/p/[pid]/problem-page.tsx
+++ b/app/c/[cid]/p/[pid]/problem-page.tsx
@@ -1,9 +1,10 @@
-"use client";
-
 import Link from "next/link";
 import Title from "./title";
 import Statement from "./statement";
 import Spoilers from "./spoilers";
+import Answer from "./answer";
+import Solution from "./solution";
+import AddSolution from "./add-solution";
 import type { Props } from "./types";
 import Comments from "./comments";
 import ArchiveToggle from "./archive-toggle";
@@ -12,10 +13,9 @@ import Likes from "@/components/likes";
 import LockedPage from "./locked-page";
 import Testsolve from "./testsolve";
 import Leaderboard from "./leaderboard";
-import { canEditProblem, needsTestsolveToView } from "@/lib/permissions";
-import { testsolveDeadline, testsolveTimeMinutes } from "@/lib/testsolve";
+import { canEditProblem } from "@/lib/permissions";
+import { problemView } from "./view";
 import BackButton from "@/components/back-button";
-import { useRouter } from "next/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { Filter, filterToString } from "@/lib/filter";
@@ -53,10 +53,11 @@ interface PropsWithFilter extends Props {
 }
 
 export default function ProblemPage(props: PropsWithFilter) {
-  const router = useRouter();
   const { problem, collection, permission, userId, authors, filter } = props;
 
   const filterStr = filterToString(filter);
+  const canEdit = canEditProblem(problem, permission, authors);
+  const view = problemView(props);
 
   let written_by;
   if (
@@ -72,89 +73,78 @@ export default function ProblemPage(props: PropsWithFilter) {
 
   const { subject, gradient } = subjectToGradient[problem.subject];
 
-  // TODO: make this a separate Testsolving component
   let testsolveOrAnswers;
-  if (needsTestsolveToView(collection, problem, permission, authors)) {
-    const difficulty = problem.difficulty;
-    if (difficulty === null || difficulty === 0) {
-      throw new Error(
-        "Difficulty is null or zero, cannot determine testsolve time",
-      );
-    }
-
-    const solveAttempt = problem.solveAttempts.find(
-      (attempt) => attempt.userId === userId,
+  if (view.kind === "locked") {
+    testsolveOrAnswers = (
+      <LockedPage
+        problemId={problem.id}
+        time={`${view.timeMinutes} minutes`}
+        unsolved={view.unsolved}
+      />
     );
-    if (solveAttempt === undefined) {
-      testsolveOrAnswers = (
-        <LockedPage
-          problem={problem}
-          time={`${testsolveTimeMinutes(difficulty)} minutes`}
-          unsolved={problem.solveAttempts.every(
-            (attempt) => attempt.solvedAt === null,
-          )}
+  } else if (view.kind === "testsolving") {
+    testsolveOrAnswers = (
+      <div>
+        <div className="mb-8">
+          <Statement {...props} />
+        </div>
+        <hr className="my-8" />
+        <Testsolve
+          problemId={problem.id}
+          deadline={view.deadline}
+          answerFormat={collection.answerFormat}
         />
-      );
-    } else {
-      const deadline = testsolveDeadline(solveAttempt.startedAt, difficulty);
-      const finished =
-        new Date() >= deadline ||
-        solveAttempt.gaveUp ||
-        solveAttempt.solvedAt !== null;
-
-      if (finished) {
-        // TODO: move this into a component
-        testsolveOrAnswers = (
-          <div>
-            <div className="mb-4">
-              <Statement {...props} />
-            </div>
-            {written_by}
-            <Spoilers {...props} />
-            {collection.requireTestsolve && (
-              <Leaderboard
-                solveAttempts={problem.solveAttempts}
-                userId={userId}
-                canViewAll={canEditProblem(problem, permission, authors)}
-              />
-            )}
-            <Comments {...props} />
-          </div>
-        );
-      } else {
-        // Currently testsolving
-        // TODO: show timer, input box, give up button
-        testsolveOrAnswers = (
-          <div>
-            <div className="mb-8">
-              <Statement {...props} />
-            </div>
-            <hr className="my-8" />
-            <Testsolve
-              problem={problem}
-              deadline={deadline}
-              answerFormat={collection.answerFormat}
-            />
-          </div>
-        );
-      }
-    }
+      </div>
+    );
   } else {
+    let answer = null;
+    if (problem.answer !== null) {
+      answer = (
+        <div className="my-8">
+          <Answer {...props} />
+        </div>
+      );
+    }
+
+    let solution = null;
+    if (problem.solutions.length > 0) {
+      solution = (
+        <div className="my-8">
+          <Solution
+            solution={problem.solutions[0]}
+            permission={permission}
+            authors={authors}
+          />
+        </div>
+      );
+    } else if (authors.length > 0) {
+      solution = (
+        <AddSolution problemId={problem.id} authorId={authors[0].id} />
+      );
+    }
+
     testsolveOrAnswers = (
       <div>
         <div className="mb-4">
           <Statement {...props} />
         </div>
         {written_by}
-        <Spoilers {...props} />
+        {answer === null && solution === null ? (
+          <div className="py-8"></div>
+        ) : (
+          <Spoilers>
+            {answer}
+            {solution}
+          </Spoilers>
+        )}
         {collection.requireTestsolve && (
           <Leaderboard
             solveAttempts={problem.solveAttempts}
             userId={userId}
-            canViewAll={canEditProblem(problem, permission, authors)}
+            canViewAll={canEdit}
           />
         )}
-        <Comments {...props} />
+        <Comments problemId={problem.id} comments={problem.comments} />
       </div>
     );
   }
@@ -162,17 +152,6 @@ export default function ProblemPage(props: PropsWithFilter) {
   const currentPid = problem.pid;
   const nextPid = incrementPid(currentPid);
   const prevPid = decrementPid(currentPid);
-  const hasPrevProblem = prevPid !== null;
-
-  const handleNextProblem = () => {
-    router.push(`/c/${collection.cid}/p/${nextPid}${filterStr}`);
-  };
-
-  const handlePrevProblem = () => {
-    if (hasPrevProblem) {
-      router.push(`/c/${collection.cid}/p/${prevPid}${filterStr}`);
-    }
-  };
 
   return (
     <div className="whitespace-pre-wrap break-words p-8 text-slate-800">
@@ -211,41 +190,51 @@ export default function ProblemPage(props: PropsWithFilter) {
             </div>
           </div>
           <div className="mt-2 space-y-3 text-base">
-            <Likes problem={problem} userId={userId} />
+            <Likes
+              problem={{ id: problem.id, likes: problem.likes }}
+              userId={userId}
+            />
             {problem.difficulty !== null && problem.difficulty > 0 && (
               <Lightbulbs difficulty={problem.difficulty} />
             )}
           </div>
         </div>
 
-        {/* Statement should also be hidden if they haven't clicked "Start testsolve" */}
         {testsolveOrAnswers}
-        {canEditProblem(problem, permission, authors) && (
+        {canEdit && (
           <div className="mt-8">
-            <ArchiveToggle {...props} />
+            <ArchiveToggle
+              problemId={problem.id}
+              isArchived={problem.isArchived}
+            />
           </div>
         )}
 
         <div className="mt-4 flex items-center justify-between">
-          <button
-            onClick={handlePrevProblem}
-            disabled={!hasPrevProblem}
-            className={`flex items-center rounded px-4 py-2 text-sm font-bold transition-colors ${
-              hasPrevProblem
-                ? "text-slate-500 hover:text-slate-700"
-                : "cursor-not-allowed text-slate-300"
-            }`}
-          >
-            <FontAwesomeIcon icon={faArrowLeft} className="mr-2" />
-            Previous
-          </button>
-          <button
-            onClick={handleNextProblem}
+          {prevPid === null ? (
+            <button
+              disabled
+              className="flex cursor-not-allowed items-center rounded px-4 py-2 text-sm font-bold text-slate-300 transition-colors"
+            >
+              <FontAwesomeIcon icon={faArrowLeft} className="mr-2" />
+              Previous
+            </button>
+          ) : (
+            <Link
+              href={`/c/${collection.cid}/p/${prevPid}${filterStr}`}
+              className="flex items-center rounded px-4 py-2 text-sm font-bold text-slate-500 transition-colors hover:text-slate-700"
+            >
+              <FontAwesomeIcon icon={faArrowLeft} className="mr-2" />
+              Previous
+            </Link>
+          )}
+          <Link
+            href={`/c/${collection.cid}/p/${nextPid}${filterStr}`}
             className="flex items-center rounded px-4 py-2 text-sm font-bold text-slate-500 transition-colors hover:text-slate-700"
           >
             Next
             <FontAwesomeIcon icon={faArrowRight} className="ml-2" />
-          </button>
+          </Link>
         </div>
       </div>
     </div>

--- a/app/c/[cid]/p/[pid]/spoilers.tsx
+++ b/app/c/[cid]/p/[pid]/spoilers.tsx
@@ -1,66 +1,24 @@
 "use client";
 
 import { useState } from "react";
-import Answer from "./answer";
-import Solution from "./solution";
-import AddSolution from "./add-solution";
-import type { Props } from "./types";
 
-export default function Spoilers(props: Props) {
-  const { problem, permission, authors } = props;
+/**
+ * Hides its children (the answer and solution, rendered by the server) behind
+ * a "Show spoilers" button. This is a courtesy for readers, not an access
+ * control: the page only renders spoilers for users allowed to see them.
+ */
+export default function Spoilers({ children }: { children: React.ReactNode }) {
   const [hidden, setHidden] = useState(true);
 
-  let answer, solution;
-  if (problem.answer !== null) {
-    answer = (
-      <div className="my-8">
-        <Answer {...props} />
-      </div>
-    );
-  } else {
-    answer = null;
-  }
-
-  if (problem.solutions.length > 0) {
-    const sol = problem.solutions[0];
-    solution = (
-      <div className="my-8">
-        <Solution solution={sol} permission={permission} authors={authors} />
-      </div>
-    );
-  } else if (authors.length > 0) {
-    solution = <AddSolution problem={problem} authorId={authors[0].id} />;
-  } else {
-    solution = null;
-  }
-
-  if (answer === null && solution === null) {
-    return <div className="py-8"></div>;
-  } else {
-    if (hidden) {
-      return (
-        <div className="my-12">
-          <button
-            onClick={() => setHidden(false)}
-            className="w-44 rounded-md bg-violet-500 py-4 text-base font-semibold leading-none text-slate-50 hover:bg-violet-600"
-          >
-            Show spoilers
-          </button>
-        </div>
-      );
-    } else {
-      return (
-        <div className="my-12">
-          <button
-            onClick={() => setHidden(true)}
-            className="w-44 rounded-md bg-violet-500 py-4 text-base font-semibold leading-none text-slate-50 hover:bg-violet-600"
-          >
-            Hide spoilers
-          </button>
-          {answer}
-          {solution}
-        </div>
-      );
-    }
-  }
+  return (
+    <div className="my-12">
+      <button
+        onClick={() => setHidden(!hidden)}
+        className="w-44 rounded-md bg-violet-500 py-4 text-base font-semibold leading-none text-slate-50 hover:bg-violet-600"
+      >
+        {hidden ? "Show spoilers" : "Hide spoilers"}
+      </button>
+      {!hidden && children}
+    </div>
+  );
 }

--- a/app/c/[cid]/p/[pid]/statement.tsx
+++ b/app/c/[cid]/p/[pid]/statement.tsx
@@ -8,7 +8,11 @@ export default function Statement(props: Props) {
   const canEdit = canEditProblem(problem, permission, authors);
 
   if (canEdit) {
-    return <EditableStatement problem={problem} />;
+    return (
+      <EditableStatement
+        problem={{ id: problem.id, statement: problem.statement }}
+      />
+    );
   } else {
     return <Latex>{`${problem.statement}`}</Latex>;
   }

--- a/app/c/[cid]/p/[pid]/testsolve.tsx
+++ b/app/c/[cid]/p/[pid]/testsolve.tsx
@@ -6,7 +6,6 @@ import AimeInput from "@/components/aime-input";
 import { useState } from "react";
 import Label from "@/components/label";
 import { AnswerFormat } from "@prisma/client";
-import { ProblemProps } from "./types";
 import SubmitButton from "@/components/submit-button";
 import { giveUpTestsolve, submitTestsolve } from "./actions";
 import { wrapAction } from "@/lib/server-actions";
@@ -14,11 +13,11 @@ import IntegerInput from "@/components/integer-input";
 
 // TODO: fix loading spinners for the two submit buttons. Probably need to show a single loading spinner outside of the buttons. That also lets us keep the same button text and width
 export default function Testsolve({
-  problem,
+  problemId,
   deadline,
   answerFormat,
 }: {
-  problem: ProblemProps;
+  problemId: number;
   deadline: Date;
   answerFormat: AnswerFormat;
 }) {
@@ -44,7 +43,7 @@ export default function Testsolve({
   return (
     <div>
       <form
-        action={() => trySubmitTestsolve(problem.id, answer)}
+        action={() => trySubmitTestsolve(problemId, answer)}
         className="mb-8"
       >
         <Label text="ANSWER" />
@@ -66,7 +65,7 @@ export default function Testsolve({
         <div className="my-4 flex items-center gap-x-6">
           <SubmitButton className="flex-grow-0">Submit</SubmitButton>
           <SubmitButton
-            onClick={() => tryGiveUpTestsolve(problem.id)}
+            onClick={() => tryGiveUpTestsolve(problemId)}
             className="flex-grow-0 bg-red-500 shadow-red-500/20 hover:bg-red-600 hover:shadow-red-500/20 focus-visible:ring-red-300 active:bg-red-700 active:shadow-red-500/20 disabled:bg-red-300"
           >
             Give Up

--- a/app/c/[cid]/p/[pid]/title.tsx
+++ b/app/c/[cid]/p/[pid]/title.tsx
@@ -19,7 +19,11 @@ export default function Title(props: Props) {
         {problem.pid}.
       </span>
       <div className="w-full text-slate-900">
-        {canEdit ? <EditableTitle problem={problem} /> : problem.title}
+        {canEdit ? (
+          <EditableTitle problem={{ id: problem.id, title: problem.title }} />
+        ) : (
+          problem.title
+        )}
       </div>
     </h2>
   );

--- a/app/c/[cid]/p/[pid]/view.ts
+++ b/app/c/[cid]/p/[pid]/view.ts
@@ -1,0 +1,47 @@
+import { needsTestsolveToView } from "@/lib/permissions";
+import { testsolveDeadline, testsolveTimeMinutes } from "@/lib/testsolve";
+import type { Props } from "./types";
+
+/**
+ * What this user may see of the problem right now. Decided on the server so
+ * that a locked problem's statement, answer, solutions, comments and other
+ * users' attempts never reach the browser.
+ */
+export type ProblemView =
+  | { kind: "locked"; timeMinutes: number; unsolved: boolean }
+  | { kind: "testsolving"; deadline: Date }
+  | { kind: "unlocked" };
+
+export function problemView(props: Props): ProblemView {
+  const { problem, collection, permission, userId, authors } = props;
+  if (!needsTestsolveToView(collection, problem, permission, authors)) {
+    return { kind: "unlocked" };
+  }
+
+  const difficulty = problem.difficulty;
+  if (difficulty === null || difficulty === 0) {
+    throw new Error(
+      "Difficulty is null or zero, cannot determine testsolve time",
+    );
+  }
+
+  const solveAttempt = problem.solveAttempts.find(
+    (attempt) => attempt.userId === userId,
+  );
+  if (solveAttempt === undefined) {
+    return {
+      kind: "locked",
+      timeMinutes: testsolveTimeMinutes(difficulty),
+      unsolved: problem.solveAttempts.every(
+        (attempt) => attempt.solvedAt === null,
+      ),
+    };
+  }
+
+  const deadline = testsolveDeadline(solveAttempt.startedAt, difficulty);
+  const finished =
+    new Date() >= deadline ||
+    solveAttempt.gaveUp ||
+    solveAttempt.solvedAt !== null;
+  return finished ? { kind: "unlocked" } : { kind: "testsolving", deadline };
+}

--- a/test/integration/pages/client-payload.ts
+++ b/test/integration/pages/client-payload.ts
@@ -1,0 +1,51 @@
+import { isValidElement, type ReactNode } from "react";
+
+/**
+ * Approximates the RSC payload Next.js would send to the browser for a page
+ * element: server components (plain functions) are expanded until only host
+ * elements and client components remain, and everything left, including all
+ * the props handed to client components, is returned as plain data.
+ *
+ * In Vitest there is no real server/client boundary, so the caller lists the
+ * client components. Anything not listed is treated as a server component
+ * and rendered in place.
+ */
+export async function clientPayload(
+  node: ReactNode,
+  clientComponents: Set<unknown>,
+): Promise<unknown> {
+  if (Array.isArray(node)) {
+    const out = [];
+    for (const child of node as ReactNode[]) {
+      out.push(await clientPayload(child, clientComponents));
+    }
+    return out;
+  }
+  if (!isValidElement(node)) {
+    return node ?? null;
+  }
+  const { type, props } = node as { type: unknown; props: unknown };
+  const record = props as Record<string, unknown>;
+
+  if (typeof type === "function" && !clientComponents.has(type)) {
+    const rendered = (await (type as (p: unknown) => unknown)(
+      props,
+    )) as ReactNode;
+    return clientPayload(rendered, clientComponents);
+  }
+
+  const name =
+    typeof type === "string"
+      ? type
+      : ((type as { displayName?: string; name?: string }).displayName ??
+        (type as { name?: string }).name ??
+        "component");
+  const serialized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    serialized[key] =
+      isValidElement(value) || Array.isArray(value)
+        ? await clientPayload(value as ReactNode, clientComponents)
+        : value;
+  }
+  return { $: name, props: serialized };
+}

--- a/test/integration/pages/problem.test.ts
+++ b/test/integration/pages/problem.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import Page from "@/app/c/[cid]/p/[pid]/page";
+import AddSolution from "@/app/c/[cid]/p/[pid]/add-solution";
+import ArchiveToggle from "@/app/c/[cid]/p/[pid]/archive-toggle";
+import Comments from "@/app/c/[cid]/p/[pid]/comments";
+import CountdownTimer from "@/app/c/[cid]/p/[pid]/countdown-timer";
+import EditableAnswer from "@/app/c/[cid]/p/[pid]/editable-answer";
+import EditableSolution from "@/app/c/[cid]/p/[pid]/editable-solution";
+import EditableStatement from "@/app/c/[cid]/p/[pid]/editable-statement";
+import EditableTitle from "@/app/c/[cid]/p/[pid]/editable-title";
+import LockedPage from "@/app/c/[cid]/p/[pid]/locked-page";
+import Spoilers from "@/app/c/[cid]/p/[pid]/spoilers";
+import Testsolve from "@/app/c/[cid]/p/[pid]/testsolve";
+import BackButton from "@/components/back-button";
+import Latex from "@/components/latex";
+import Likes from "@/components/likes";
+import prisma from "@/lib/prisma";
+import {
+  createCollection,
+  createPermission,
+  createProblem,
+  createSolution,
+  createUser,
+} from "../factories";
+import { signInAs } from "../session";
+import { clientPayload } from "./client-payload";
+
+// Every component under the problem page with a "use client" directive.
+// Their props are what Next.js serializes into the RSC payload.
+const clientComponents = new Set<unknown>([
+  AddSolution,
+  ArchiveToggle,
+  Comments,
+  CountdownTimer,
+  EditableAnswer,
+  EditableSolution,
+  EditableStatement,
+  EditableTitle,
+  LockedPage,
+  Spoilers,
+  Testsolve,
+  BackButton,
+  Latex,
+  Likes,
+]);
+
+const SECRETS = {
+  statement: "STATEMENT-SECRET",
+  answer: "ANSWER-SECRET",
+  solution: "SOLUTION-SECRET",
+  comment: "COMMENT-SECRET",
+  otherUser: "OTHER-USER-SECRET",
+};
+
+/** A testsolving collection with one problem written by someone else, and a serious testsolver signed in. */
+async function setup() {
+  const collection = await createCollection({ requireTestsolve: true });
+  const author = await createUser({ name: SECRETS.otherUser });
+  const problem = await createProblem(collection, {
+    title: "Visible title",
+    statement: SECRETS.statement,
+    answer: SECRETS.answer,
+    difficulty: 2,
+  });
+  await createSolution(problem, { text: SECRETS.solution });
+  await prisma.comment.create({
+    data: { problemId: problem.id, userId: author.id, text: SECRETS.comment },
+  });
+  // Someone else has already solved it, so the leaderboard has an entry.
+  await prisma.solveAttempt.create({
+    data: {
+      userId: author.id,
+      problemId: problem.id,
+      solvedAt: new Date(),
+      numSubmissions: 1,
+    },
+  });
+
+  const testsolver = await createUser();
+  await createPermission(testsolver, collection, "TeamMember", {
+    testsolverType: "Serious",
+    seriousTestsolverStartedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  });
+  signInAs(testsolver);
+  return { collection, problem, testsolver };
+}
+
+async function payloadFor(cid: string, pid: string): Promise<string> {
+  const page = await Page({ params: { cid, pid }, searchParams: {} });
+  return JSON.stringify(await clientPayload(page, clientComponents));
+}
+
+describe("problem page client payload", () => {
+  it("sends nothing but the title before a serious testsolver starts", async () => {
+    const { collection, problem } = await setup();
+
+    const payload = await payloadFor(collection.cid, problem.pid);
+
+    expect(payload).toContain("Visible title");
+    // The locked island gets only what it renders: the id, the time limit,
+    // and whether anyone has solved it yet.
+    expect(payload).toContain(
+      JSON.stringify({
+        $: "LockedPage",
+        props: { problemId: problem.id, time: "15 minutes", unsolved: false },
+      }),
+    );
+    for (const secret of Object.values(SECRETS)) {
+      expect(payload).not.toContain(secret);
+    }
+  });
+
+  it("sends the statement but no answer, solution, comments or names while testsolving", async () => {
+    const { collection, problem, testsolver } = await setup();
+    await prisma.solveAttempt.create({
+      data: { userId: testsolver.id, problemId: problem.id },
+    });
+
+    const payload = await payloadFor(collection.cid, problem.pid);
+
+    expect(payload).toContain(SECRETS.statement);
+    expect(payload).toContain('"$":"Testsolve"');
+    for (const secret of [
+      SECRETS.answer,
+      SECRETS.solution,
+      SECRETS.comment,
+      SECRETS.otherUser,
+    ]) {
+      expect(payload).not.toContain(secret);
+    }
+  });
+
+  it("sends everything once the testsolve is finished", async () => {
+    const { collection, problem, testsolver } = await setup();
+    await prisma.solveAttempt.create({
+      data: { userId: testsolver.id, problemId: problem.id, gaveUp: true },
+    });
+
+    const payload = await payloadFor(collection.cid, problem.pid);
+
+    for (const secret of Object.values(SECRETS)) {
+      expect(payload).toContain(secret);
+    }
+  });
+
+  it("sends everything to a casual testsolver straight away", async () => {
+    const { collection, problem, testsolver } = await setup();
+    await prisma.permission.update({
+      where: {
+        userId_collectionId: {
+          userId: testsolver.id,
+          collectionId: collection.id,
+        },
+      },
+      data: { testsolverType: "Casual" },
+    });
+
+    const payload = await payloadFor(collection.cid, problem.pid);
+
+    for (const secret of Object.values(SECRETS)) {
+      expect(payload).toContain(secret);
+    }
+  });
+});

--- a/test/unit/app/problem-view.test.ts
+++ b/test/unit/app/problem-view.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { problemView } from "@/app/c/[cid]/p/[pid]/view";
+import type { Props } from "@/app/c/[cid]/p/[pid]/types";
+
+const now = Date.now();
+const MINUTE = 60_000;
+
+function props(overrides: {
+  requireTestsolve?: boolean;
+  testsolverType?: "Serious" | "Casual" | null;
+  difficulty?: number | null;
+  attempts?: Props["problem"]["solveAttempts"];
+}): Props {
+  const {
+    requireTestsolve = true,
+    testsolverType = "Serious",
+    difficulty = 2,
+    attempts = [],
+  } = overrides;
+  return {
+    userId: "me",
+    collection: { requireTestsolve } as Props["collection"],
+    permission: {
+      accessLevel: "TeamMember",
+      testsolverType,
+      seriousTestsolverStartedAt: new Date(now - 10 * MINUTE),
+    },
+    authors: [],
+    problem: {
+      id: 1,
+      createdAt: new Date(now - 5 * MINUTE),
+      difficulty,
+      authors: [{ id: 99, displayName: "Someone else" }],
+      solveAttempts: attempts,
+    } as unknown as Props["problem"],
+  };
+}
+
+function attempt(
+  overrides: Partial<Props["problem"]["solveAttempts"][number]> = {},
+): Props["problem"]["solveAttempts"][number] {
+  return {
+    userId: "me",
+    problemId: 1,
+    startedAt: new Date(now - 1 * MINUTE),
+    solvedAt: null,
+    numSubmissions: 0,
+    gaveUp: false,
+    user: { name: "Me" },
+    ...overrides,
+  };
+}
+
+describe("problemView", () => {
+  it("is unlocked when the user does not need to testsolve", () => {
+    expect(problemView(props({ testsolverType: "Casual" }))).toEqual({
+      kind: "unlocked",
+    });
+    expect(problemView(props({ requireTestsolve: false }))).toEqual({
+      kind: "unlocked",
+    });
+  });
+
+  it("is locked, with the time limit, before an attempt exists", () => {
+    expect(problemView(props({ difficulty: 3 }))).toEqual({
+      kind: "locked",
+      timeMinutes: 20,
+      unsolved: true,
+    });
+  });
+
+  it("reports whether anyone else has solved it while locked", () => {
+    const solvedByOther = attempt({
+      userId: "other",
+      solvedAt: new Date(),
+      user: { name: "Other" },
+    });
+    expect(problemView(props({ attempts: [solvedByOther] }))).toMatchObject({
+      kind: "locked",
+      unsolved: false,
+    });
+  });
+
+  it("is testsolving, with the deadline, during an attempt", () => {
+    const startedAt = new Date(now - 1 * MINUTE);
+    expect(
+      problemView(props({ difficulty: 1, attempts: [attempt({ startedAt })] })),
+    ).toEqual({
+      kind: "testsolving",
+      deadline: new Date(startedAt.getTime() + 10 * MINUTE),
+    });
+  });
+
+  it("is unlocked once the attempt is solved, given up, or out of time", () => {
+    expect(
+      problemView(props({ attempts: [attempt({ solvedAt: new Date() })] })),
+    ).toEqual({ kind: "unlocked" });
+    expect(
+      problemView(props({ attempts: [attempt({ gaveUp: true })] })),
+    ).toEqual({ kind: "unlocked" });
+    expect(
+      problemView(
+        props({
+          difficulty: 1,
+          attempts: [attempt({ startedAt: new Date(now - 11 * MINUTE) })],
+        }),
+      ),
+    ).toEqual({ kind: "unlocked" });
+  });
+
+  it("throws for a locked problem with no difficulty, which has no time limit", () => {
+    expect(() => problemView(props({ difficulty: null }))).toThrow(
+      "Difficulty is null or zero",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`ProblemPage` was a `"use client"` component that received the entire problem row graph as props: `answer`, `solutions`, `comments`, and every user's `solveAttempt` with their name. The "locked until testsolved" decision ran in the browser. A serious testsolver could open the network tab and read the answer before pressing "Start testsolving", which undermines the leaderboard the feature is built around.

## Why this approach

Move the decision to the server and shrink every client island to the props it actually renders. No new data layer: `page.tsx` loads exactly what it loaded before, and `view.ts` is a pure function over those props that returns `locked`, `testsolving`, or `unlocked`. The page renders a different subtree per view, so a locked problem's sensitive fields are never handed to any client component. `Spoilers` becomes a client toggle around server-rendered children, the idiomatic App Router shape, and the prev/next buttons become links, which removed the page's last reason to be a client component.

## What changed

- `problem-page.tsx`: no longer `"use client"`. Renders one of three views. Passes narrowed props to every island.
- New `view.ts`: `problemView(props)`.
- `locked-page.tsx`, `testsolve.tsx`, `add-solution.tsx`: take `problemId` instead of the whole problem.
- `comments.tsx`: takes `problemId` and `comments`. `archive-toggle.tsx`: takes `problemId` and `isArchived`.
- `editable-title/statement/answer.tsx`: prop type is the one field they edit; `title.tsx`, `statement.tsx`, `answer.tsx` pass it.
- `spoilers.tsx`: `{ children }` with the show/hide button; the answer/solution/add-solution decision moved into the page.
- Tests: `test/unit/app/problem-view.test.ts` (6) and `test/integration/pages/problem.test.ts` (4), which expands the page's server tree and asserts the locked payload contains none of the statement, answer, solution, comment, or another user's name, the testsolving payload contains the statement only, and the unlocked and casual payloads contain everything. Helper in `test/integration/pages/client-payload.ts`.

## Visible behavior changes

None intended. Every view renders the same elements as before. Prev/next are now anchor tags instead of buttons that pushed the same URL; the disabled Previous state is unchanged.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 114 passed
- `npm run test:integration`: 102 passed
- `npm run build`: success
- Dev server against the throwaway test DB, signed in with a hand-made Auth.js session cookie:
  - serious testsolver on a locked problem: HTML and `RSC: 1` payload contain the title, "15 minutes", "Testsolve to view", and none of the five seeded secret strings
  - author on the same problem: statement, spoilers button, leaderboard, discussion with the comment, archive toggle, prev/next links all present; answer present in the payload as expected
  - signed out: 307 to sign-in with the right callback

## Residual risk

`new Date() >= deadline` is now evaluated on the server at request time rather than at hydration; the countdown timer still triggers a refresh at the deadline so the page flips to the finished view as before. The Leaderboard is now server-rendered, so non-editors receive only the rows it shows rather than every attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
