### PR TITLE
refactor: server-render the collection list and filter on the server

### DIFF
--- a/app/c/[cid]/page.tsx
+++ b/app/c/[cid]/page.tsx
@@ -1,13 +1,14 @@
 import prisma from "@/lib/prisma";
+import { redirect } from "next/navigation";
 import ProblemList from "./problem-list";
 import { Collection, Problem } from "@prisma/client";
 import { ProblemProps } from "./types";
 import { requireCollectionAccess } from "@/lib/collection-access";
-import { parseFilter } from "@/lib/filter";
+import { applyFilter, filterToString, parseFilter } from "@/lib/filter";
 
 function sortByNew(p1: Problem, p2: Problem): number {
-  const t1 = p1.createdAt;
-  const t2 = p2.createdAt;
+  const t1 = p1.createdAt.getTime();
+  const t2 = p2.createdAt.getTime();
   if (t1 !== t2) {
     return t1 > t2 ? -1 : 1;
   } else {
@@ -18,16 +19,6 @@ function sortByNew(p1: Problem, p2: Problem): number {
 async function getProblems(collection: Collection): Promise<ProblemProps[]> {
   const problems = await prisma.problem.findMany({
     where: { collectionId: collection.id },
-    orderBy: [
-      {
-        solveAttempts: {
-          _count: "asc",
-        },
-      },
-      {
-        createdAt: "desc",
-      },
-    ],
     include: {
       // TODO: match ProblemProps in [cid]/types
       authors: {
@@ -58,7 +49,7 @@ export default async function Page({
   searchParams,
 }: {
   params: Params;
-  searchParams: { page?: string; subject?: string };
+  searchParams: { [key: string]: string | string[] | undefined };
 }) {
   const { cid } = params;
   const filter = parseFilter(searchParams);
@@ -66,7 +57,7 @@ export default async function Page({
     await requireCollectionAccess(cid, `/c/${cid}`);
   const problems = await getProblems(collection);
 
-  const solvedAttempts = await prisma.solveAttempt.findMany({
+  const attempts = await prisma.solveAttempt.findMany({
     where: {
       userId,
       problem: {
@@ -77,18 +68,22 @@ export default async function Page({
       problemId: true,
     },
   });
+  const attemptedProblemIds = attempts.map((attempt) => attempt.problemId);
 
-  const solvedProblemIds = solvedAttempts.map((attempt) => attempt.problemId);
+  const { page, numPages } = applyFilter(problems, filter, attemptedProblemIds);
+  if (filter.page > numPages) {
+    redirect(`/c/${cid}${filterToString({ ...filter, page: numPages })}`);
+  }
 
   return (
     <ProblemList
       collection={collection}
-      problems={problems}
+      problems={page}
+      numPages={numPages}
       userId={userId}
       permission={permission}
       authors={authors}
       filter={filter}
-      solvedProblemIds={solvedProblemIds}
     />
   );
 }

--- a/app/c/[cid]/problem-card.tsx
+++ b/app/c/[cid]/problem-card.tsx
@@ -60,7 +60,10 @@ export default function ProblemCard({
             {problem.difficulty !== null && problem.difficulty > 0 && (
               <Lightbulbs difficulty={problem.difficulty} />
             )}
-            <Likes problem={problem} userId={userId} />
+            <Likes
+              problem={{ id: problem.id, likes: problem.likes }}
+              userId={userId}
+            />
           </div>
         </div>
         {locked ? (
@@ -76,7 +79,10 @@ export default function ProblemCard({
           </div>
         )}
         <div className="flex h-6 items-center justify-between sm:hidden">
-          <Likes problem={problem} userId={userId} />
+          <Likes
+            problem={{ id: problem.id, likes: problem.likes }}
+            userId={userId}
+          />
           {problem.difficulty !== null && problem.difficulty > 0 && (
             <Lightbulbs difficulty={problem.difficulty} />
           )}

--- a/app/c/[cid]/problem-list.tsx
+++ b/app/c/[cid]/problem-list.tsx
@@ -1,67 +1,28 @@
-"use client";
-
 import ProblemCard from "./problem-card";
 import { Collection, Permission } from "@prisma/client";
 import { ProblemProps } from "./types";
-import { Filter, filterToString } from "@/lib/filter";
+import { Filter } from "@/lib/filter";
 import { ProblemListPagination } from "@/components/problem-list-pagination";
 import { ProblemListSidebar } from "@/components/problem-list-sidebar";
-import { useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
 
 export default function ProblemList({
   collection,
   problems,
+  numPages,
   userId,
   authors,
   permission,
   filter,
-  solvedProblemIds,
 }: {
   collection: Collection;
+  /** The current page of problems, already filtered. */
   problems: ProblemProps[];
+  numPages: number;
   userId: string;
   authors: { id: number }[];
   permission: Permission;
   filter: Filter;
-  solvedProblemIds: number[];
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
-
-  problems = problems.filter(
-    (problem) => problem.isArchived === filter.archived,
-  );
-  if (filter.subjects.length > 0) {
-    problems = problems.filter((problem) =>
-      filter.subjects.includes(problem.subject),
-    );
-  }
-  if (filter.unsolvedOnly) {
-    problems = problems.filter(
-      (problem) => !solvedProblemIds.includes(problem.id),
-    );
-  }
-  if (filter.search !== "") {
-    const lowerQuery = filter.search.toLowerCase();
-    problems = problems.filter(
-      (problem) =>
-        problem.title.toLowerCase().includes(lowerQuery) ||
-        problem.statement.toLowerCase().includes(lowerQuery),
-    );
-  }
-
-  const numPages = Math.max(Math.ceil(problems.length / 20), 1);
-
-  useEffect(() => {
-    if (filter.page > numPages) {
-      const newParams = filterToString({ ...filter, page: numPages });
-      router.replace(`${pathname}${newParams}`);
-    }
-  }, [filter, numPages, router, pathname]);
-
-  problems = problems.slice(20 * (filter.page - 1), 20 * filter.page);
-
   return (
     <div className="p-4 sm:p-8 xl:px-12 xl:py-24">
       <div className="flex flex-col xl:flex-row xl:justify-center xl:gap-x-12">

--- a/components/problem-list-filter.tsx
+++ b/components/problem-list-filter.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import {
   Collection,

--- a/components/problem-list-search.tsx
+++ b/components/problem-list-search.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Filter, filterToString } from "@/lib/filter";

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -60,3 +60,53 @@ export function filterToString(filter: Filter): string {
   const queryString = queryParams.toString();
   return queryString ? `?${queryString}` : "";
 }
+
+export const PAGE_SIZE = 20;
+
+interface FilterableProblem {
+  id: number;
+  title: string;
+  statement: string;
+  subject: Subject;
+  isArchived: boolean;
+}
+
+/**
+ * Applies a Filter to a collection's problems and picks the requested page.
+ * `attemptedProblemIds` are the problems the user has started testsolving;
+ * "unsolved only" hides those.
+ */
+export function applyFilter<T extends FilterableProblem>(
+  problems: T[],
+  filter: Filter,
+  attemptedProblemIds: number[],
+): { page: T[]; numPages: number } {
+  let matching = problems.filter(
+    (problem) => problem.isArchived === filter.archived,
+  );
+  if (filter.subjects.length > 0) {
+    matching = matching.filter((problem) =>
+      filter.subjects.includes(problem.subject),
+    );
+  }
+  if (filter.unsolvedOnly) {
+    matching = matching.filter(
+      (problem) => !attemptedProblemIds.includes(problem.id),
+    );
+  }
+  if (filter.search !== "") {
+    const lowerQuery = filter.search.toLowerCase();
+    matching = matching.filter(
+      (problem) =>
+        problem.title.toLowerCase().includes(lowerQuery) ||
+        problem.statement.toLowerCase().includes(lowerQuery),
+    );
+  }
+
+  const numPages = Math.max(Math.ceil(matching.length / PAGE_SIZE), 1);
+  const page = matching.slice(
+    PAGE_SIZE * (filter.page - 1),
+    PAGE_SIZE * filter.page,
+  );
+  return { page, numPages };
+}

--- a/test/integration/pages/collection.test.ts
+++ b/test/integration/pages/collection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import Page from "@/app/c/[cid]/page";
+import BackButton from "@/components/back-button";
+import Latex from "@/components/latex";
+import Likes from "@/components/likes";
+import { ProblemListFilter } from "@/components/problem-list-filter";
+import { ProblemListPagination } from "@/components/problem-list-pagination";
+import { ProblemListSearch } from "@/components/problem-list-search";
+import prisma from "@/lib/prisma";
+import {
+  createCollection,
+  createPermission,
+  createProblem,
+  createUser,
+} from "../factories";
+import { expectRedirect } from "../navigation";
+import { signInAs } from "../session";
+import { clientPayload } from "./client-payload";
+
+const clientComponents = new Set<unknown>([
+  BackButton,
+  Latex,
+  Likes,
+  ProblemListFilter,
+  ProblemListPagination,
+  ProblemListSearch,
+]);
+
+async function payloadFor(
+  cid: string,
+  searchParams: Record<string, string> = {},
+): Promise<string> {
+  const page = await Page({ params: { cid }, searchParams });
+  return JSON.stringify(await clientPayload(page, clientComponents));
+}
+
+describe("collection page", () => {
+  it("sends a locked problem's title but not its statement to a serious testsolver", async () => {
+    const collection = await createCollection({ requireTestsolve: true });
+    await createProblem(collection, {
+      title: "Locked title",
+      statement: "LOCKED-STATEMENT-SECRET",
+    });
+    const solver = await createUser();
+    await createPermission(solver, collection, "TeamMember", {
+      testsolverType: "Serious",
+      seriousTestsolverStartedAt: new Date(Date.now() - 60_000),
+    });
+    signInAs(solver);
+
+    const payload = await payloadFor(collection.cid);
+
+    expect(payload).toContain("Locked title");
+    expect(payload).toContain("Testsolve to view");
+    expect(payload).not.toContain("LOCKED-STATEMENT-SECRET");
+  });
+
+  it("sends statements to a casual testsolver", async () => {
+    const collection = await createCollection({ requireTestsolve: true });
+    await createProblem(collection, { statement: "VISIBLE-STATEMENT" });
+    const solver = await createUser();
+    await createPermission(solver, collection, "TeamMember", {
+      testsolverType: "Casual",
+    });
+    signInAs(solver);
+
+    expect(await payloadFor(collection.cid)).toContain("VISIBLE-STATEMENT");
+  });
+
+  it("applies the filter on the server, newest first", async () => {
+    const collection = await createCollection();
+    const older = await createProblem(collection, {
+      title: "Older",
+      subject: "Geometry",
+      createdAt: new Date("2024-01-01"),
+    });
+    const newer = await createProblem(collection, {
+      title: "Newer",
+      subject: "Geometry",
+      createdAt: new Date("2024-02-01"),
+    });
+    await createProblem(collection, {
+      title: "Algebra one",
+      subject: "Algebra",
+    });
+    await createProblem(collection, { title: "Archived", isArchived: true });
+    const member = await createUser();
+    await createPermission(member, collection, "TeamMember");
+    signInAs(member);
+
+    const all = await payloadFor(collection.cid);
+    expect(all.indexOf("Newer")).toBeLessThan(all.indexOf("Older"));
+    expect(all).toContain("Algebra one");
+    expect(all).not.toContain("Archived");
+
+    const geometry = await payloadFor(collection.cid, { subject: "g" });
+    expect(geometry).toContain(newer.title);
+    expect(geometry).toContain(older.title);
+    expect(geometry).not.toContain("Algebra one");
+
+    const archived = await payloadFor(collection.cid, { archived: "true" });
+    expect(archived).toContain("Archived");
+    expect(archived).not.toContain("Newer");
+  });
+
+  it("redirects a page number past the end to the last page", async () => {
+    const collection = await createCollection();
+    await createProblem(collection);
+    const member = await createUser();
+    await createPermission(member, collection, "TeamMember");
+    signInAs(member);
+
+    await expectRedirect(
+      Page({ params: { cid: collection.cid }, searchParams: { page: "9" } }),
+      `/c/${collection.cid}`,
+    );
+    expect(await prisma.problem.count()).toBe(1);
+  });
+});

--- a/test/unit/lib/apply-filter.test.ts
+++ b/test/unit/lib/apply-filter.test.ts
@@ -1,0 +1,102 @@
+import type { Subject } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { type Filter, PAGE_SIZE, applyFilter } from "@/lib/filter";
+
+const noFilter: Filter = {
+  subjects: [],
+  search: "",
+  archived: false,
+  page: 1,
+  unsolvedOnly: false,
+};
+
+let nextId = 1;
+function problem(
+  overrides: Partial<{
+    title: string;
+    statement: string;
+    subject: Subject;
+    isArchived: boolean;
+  }> = {},
+) {
+  const id = nextId++;
+  return {
+    id,
+    title: `Problem ${id}`,
+    statement: `Statement ${id}`,
+    subject: "Algebra" as Subject,
+    isArchived: false,
+    ...overrides,
+  };
+}
+
+describe("applyFilter", () => {
+  it("shows only unarchived problems by default, and only archived ones when asked", () => {
+    const live = problem();
+    const archived = problem({ isArchived: true });
+
+    expect(applyFilter([live, archived], noFilter, []).page).toEqual([live]);
+    expect(
+      applyFilter([live, archived], { ...noFilter, archived: true }, []).page,
+    ).toEqual([archived]);
+  });
+
+  it("keeps problems in any of the selected subjects", () => {
+    const alg = problem({ subject: "Algebra" });
+    const geo = problem({ subject: "Geometry" });
+    const nt = problem({ subject: "NumberTheory" });
+
+    expect(
+      applyFilter(
+        [alg, geo, nt],
+        { ...noFilter, subjects: ["Geometry", "NumberTheory"] },
+        [],
+      ).page,
+    ).toEqual([geo, nt]);
+  });
+
+  it("hides attempted problems when unsolvedOnly is set", () => {
+    const tried = problem();
+    const fresh = problem();
+
+    expect(
+      applyFilter([tried, fresh], { ...noFilter, unsolvedOnly: true }, [
+        tried.id,
+      ]).page,
+    ).toEqual([fresh]);
+    expect(applyFilter([tried, fresh], noFilter, [tried.id]).page).toEqual([
+      tried,
+      fresh,
+    ]);
+  });
+
+  it("searches title and statement case-insensitively", () => {
+    const byTitle = problem({ title: "Circumcenter fun" });
+    const byStatement = problem({ statement: "Let $O$ be the CIRCUMCENTER." });
+    const neither = problem();
+
+    expect(
+      applyFilter(
+        [byTitle, byStatement, neither],
+        { ...noFilter, search: "circum" },
+        [],
+      ).page,
+    ).toEqual([byTitle, byStatement]);
+  });
+
+  it("pages the matches and reports the page count", () => {
+    const problems = Array.from({ length: PAGE_SIZE + 5 }, () => problem());
+
+    const first = applyFilter(problems, noFilter, []);
+    expect(first.numPages).toBe(2);
+    expect(first.page).toEqual(problems.slice(0, PAGE_SIZE));
+
+    const second = applyFilter(problems, { ...noFilter, page: 2 }, []);
+    expect(second.page).toEqual(problems.slice(PAGE_SIZE));
+  });
+
+  it("reports one page, not zero, when nothing matches", () => {
+    const result = applyFilter([problem()], { ...noFilter, search: "zzz" }, []);
+    expect(result).toEqual({ page: [], numPages: 1 });
+  });
+});


### PR DESCRIPTION
## Problem

`ProblemList` was a `"use client"` component that received every problem in the collection, full statements included, and applied the archived, subject, unsolved, and search filters plus pagination in the browser. Each card's lock decision also ran in the browser, so a locked problem's statement sat in the payload behind its "Testsolve to view" card. The `sortByNew` comparator compared `Date` objects by identity, so its id tiebreak never ran.

## Why this approach

Move the same logic to the server rather than rewrite it. `applyFilter()` in `lib/filter.ts` is the exact in-memory filter the client had, so results are byte-identical, and it is unit-tested. The page already re-rendered on the server for every filter change, because the filter widgets call `router.replace` with new search params on a dynamic route, so this adds no round trips. The out-of-range page clamp becomes a server redirect instead of a client effect.

## What changed

- `lib/filter.ts`: `applyFilter(problems, filter, attemptedProblemIds)` and `PAGE_SIZE`.
- `app/c/[cid]/page.tsx`: filters and pages on the server; redirects when `page` exceeds the page count; `sortByNew` compares timestamps.
- `problem-list.tsx`: server component receiving the current page and `numPages`.
- `problem-card.tsx`: passes `Likes` only `{ id, likes }`.
- `problem-list-filter.tsx`, `problem-list-search.tsx`: gain the `"use client"` directive they always needed for their router hooks.
- Tests: `test/unit/lib/apply-filter.test.ts` (6) and `test/integration/pages/collection.test.ts` (4: locked statement absent for a serious testsolver, present for casual, filters and ordering applied server-side, out-of-range page redirects).

## Visible behavior changes

None intended. Same cards, same order, same filters, same pagination. The only observable difference is that a URL with a page number past the end now redirects before rendering instead of rendering an empty list and then replacing the URL client-side.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 120 passed
- `npm run test:integration`: 106 passed
- `npm run build`: success
- Dev server against the test DB with a hand-made session cookie: as a serious testsolver `/c/smoke` HTML and RSC payload show both titles and "Testsolve to view" with no statement text; `?search=second` returns only the matching card; `?page=9` redirects to `/c/smoke`; as an author both statements render and `?subject=g` returns no cards.

## Residual risk

Search still matches with JavaScript `toLowerCase().includes()` on the server, exactly as the client did, so Unicode case-folding behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
