### PR TITLE
refactor: revalidate the changed page explicitly instead of phantom cache tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Code conventions
 
-- Next.js 14 App Router with server actions. Server actions return `ActionResponse` (`{ ok: true }` / `{ ok: false, error }`) instead of throwing; build errors with `error()` from `lib/server-actions.ts`. Client components call actions through `wrapAction()` from the same file.
+- Next.js 14 App Router with server actions. Server actions return `ActionResponse` (`{ ok: true }` / `{ ok: false, error }`) instead of throwing; build errors with `error()` from `lib/server-actions.ts`. Client components call actions through `wrapAction()` from the same file (or `runAction()` when they need the result). An action that changes what a page shows calls `revalidatePath()` on that page before returning; the client then re-renders on its own, so components should not call `router.refresh()` after such an action.
 - ESLint enforces `@typescript-eslint/no-floating-promises` as an error: every un-awaited promise needs `.catch(...)` or `void`.
 - Component filenames are kebab-case. Use `cn()` from `lib/utils.ts` for class merging, not raw `clsx`.
 - shadcn/ui components live in `components/ui/`; design tokens are HSL CSS variables in `styles/globals.css`. Prettier sorts Tailwind classes via `prettier-plugin-tailwindcss`.

--- a/app/c/[cid]/add-problem/actions.ts
+++ b/app/c/[cid]/add-problem/actions.ts
@@ -6,7 +6,7 @@ import { ActionResponse, error, unexpectedError } from "@/lib/server-actions";
 import { Subject } from "@prisma/client";
 import { getCurrentUser } from "@/lib/current-user";
 import { getPermission } from "@/lib/collection-access";
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { redirect } from "next/navigation";
 
@@ -121,7 +121,7 @@ export async function addProblem(
       },
     });
 
-    revalidateTag(`collection/${collection.cid}/problems`);
+    revalidatePath(`/c/${collection.cid}`);
     redirect(`/c/${collection.cid}/p/${newProblem.pid}`);
   } catch (err) {
     if (isRedirectError(err)) {

--- a/app/c/[cid]/p/[pid]/actions.ts
+++ b/app/c/[cid]/p/[pid]/actions.ts
@@ -16,7 +16,7 @@ import {
 import { Prisma } from "@prisma/client";
 import { getCurrentUser } from "@/lib/current-user";
 import { getAuthorIds, getPermission } from "@/lib/collection-access";
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import {
   BUFFER_TIME_MILLIS,
   SUBMISSION_LIMIT,
@@ -97,7 +97,7 @@ export async function likeProblem(
       }
     }
 
-    revalidateTag(`problem/${problem.collection.cid}_${problem.pid}`);
+    revalidatePath(`/c/${problem.collection.cid}/p/${problem.pid}`);
     return { ok: true };
   } catch (err) {
     return unexpectedError("likeProblem", err);
@@ -163,7 +163,7 @@ export async function editProblem(
       },
     });
 
-    revalidateTag(`problem/${problem.collection.cid}_${problem.pid}`);
+    revalidatePath(`/c/${problem.collection.cid}/p/${problem.pid}`);
     return { ok: true };
   } catch (err) {
     return unexpectedError("editProblem", err);
@@ -194,6 +194,7 @@ export async function addComment(
         collection: {
           select: {
             id: true,
+            cid: true,
           },
         },
       },
@@ -219,7 +220,7 @@ export async function addComment(
       },
     });
 
-    revalidateTag(`problem/${problemId}/comments`);
+    revalidatePath(`/c/${problem.collection.cid}/p/${problem.pid}`);
     return { ok: true };
   } catch (err) {
     return unexpectedError("addComment", err);
@@ -460,12 +461,21 @@ export async function addSolution(
   try {
     const problem = await prisma.problem.findUnique({
       where: { id: problemId },
+      select: {
+        pid: true,
+        collection: {
+          select: {
+            id: true,
+            cid: true,
+          },
+        },
+      },
     });
     if (problem === null) {
       return error("Problem not found");
     }
 
-    const permission = await getPermission(userId, problem.collectionId);
+    const permission = await getPermission(userId, problem.collection.id);
     if (!canAddSolution(permission)) {
       return error("You do not have permission to edit this collection");
     }
@@ -482,7 +492,7 @@ export async function addSolution(
       },
     });
 
-    // TODO: revalidateTag problem.id/solutions
+    revalidatePath(`/c/${problem.collection.cid}/p/${problem.pid}`);
     return { ok: true };
   } catch (err) {
     return unexpectedError("addSolution", err);
@@ -538,7 +548,9 @@ export async function editSolution(
       },
     });
 
-    // TODO: revalidateTag problem.id/solutions
+    revalidatePath(
+      `/c/${solution.problem.collection.cid}/p/${solution.problem.pid}`,
+    );
     return { ok: true };
   } catch (err) {
     return unexpectedError("editSolution", err);

--- a/app/c/[cid]/p/[pid]/editable-solution.tsx
+++ b/app/c/[cid]/p/[pid]/editable-solution.tsx
@@ -2,7 +2,6 @@
 
 import ClickToEdit from "@/components/click-to-edit";
 import type { SolutionProps } from "./types";
-import { useRouter } from "next/navigation";
 import { editSolution } from "./actions";
 import { runAction } from "@/lib/server-actions";
 
@@ -13,16 +12,9 @@ export default function EditableSolution({
   solution: SolutionProps;
   label: React.ReactNode;
 }) {
-  const router = useRouter();
-
-  // TODO: useOptimistic instead of refreshing
   const saveSolution = async (text: string) => {
     const resp = await runAction(editSolution)(solution.id, text);
-    const saved = resp?.ok ?? false;
-    if (saved) {
-      router.refresh();
-    }
-    return saved;
+    return resp?.ok ?? false;
   };
 
   return (

--- a/test/integration/actions/add-problem.test.ts
+++ b/test/integration/actions/add-problem.test.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { describe, expect, it } from "vitest";
 import { addProblem } from "@/app/c/[cid]/add-problem/actions";
 import prisma from "@/lib/prisma";
@@ -116,9 +116,7 @@ describe("addProblem", () => {
     expect(problem.authors.map((a) => a.id)).toEqual([author.id]);
     expect(problem.solutions).toEqual([]);
     expect(problem.likes).toEqual([{ userId: user.id, problemId: problem.id }]);
-    expect(revalidateTag).toHaveBeenCalledWith(
-      `collection/${collection.cid}/problems`,
-    );
+    expect(revalidatePath).toHaveBeenCalledWith(`/c/${collection.cid}`);
   });
 
   it("creates a solution by the same author when one is given", async () => {

--- a/test/integration/actions/problem.test.ts
+++ b/test/integration/actions/problem.test.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { describe, expect, it, vi } from "vitest";
 import {
   addComment,
@@ -70,8 +70,8 @@ describe("likeProblem", () => {
     expect(await prisma.problemLike.findMany()).toEqual([
       { userId: user.id, problemId: problem.id },
     ]);
-    expect(revalidateTag).toHaveBeenCalledWith(
-      `problem/${collection.cid}_${problem.pid}`,
+    expect(revalidatePath).toHaveBeenCalledWith(
+      `/c/${collection.cid}/p/${problem.pid}`,
     );
 
     expect(await likeProblem(problem.id, false)).toEqual({ ok: true });
@@ -154,8 +154,8 @@ describe("editProblem", () => {
       answer: "Old answer",
       isArchived: false,
     });
-    expect(revalidateTag).toHaveBeenCalledWith(
-      `problem/${collection.cid}_${problem.pid}`,
+    expect(revalidatePath).toHaveBeenCalledWith(
+      `/c/${collection.cid}/p/${problem.pid}`,
     );
   });
 
@@ -278,8 +278,8 @@ describe("addComment", () => {
       { text: "first", userId: viewer.id, problemId: problem.id },
       { text: "second", userId: submitter.id, problemId: problem.id },
     ]);
-    expect(revalidateTag).toHaveBeenCalledWith(
-      `problem/${problem.id}/comments`,
+    expect(revalidatePath).toHaveBeenCalledWith(
+      `/c/${collection.cid}/p/${problem.pid}`,
     );
   });
 });
@@ -337,6 +337,9 @@ describe("addSolution", () => {
       text: "Proof by intimidation",
     });
     expect(solutions[0].authors.map((a) => a.id)).toEqual([author.id]);
+    expect(revalidatePath).toHaveBeenCalledWith(
+      `/c/${collection.cid}/p/${problem.pid}`,
+    );
   });
 });
 
@@ -369,6 +372,9 @@ describe("editSolution", () => {
         })
       ).text,
     ).toBe("After");
+    expect(revalidatePath).toHaveBeenCalledWith(
+      `/c/${collection.cid}/p/${problem.pid}`,
+    );
   });
 
   it("lets a TeamMember edit only solutions they authored", async () => {


### PR DESCRIPTION
## Problem

Actions called `revalidateTag()` with tags such as `problem/<cid>_<pid>` and `problem/<id>/comments` that no cached data carried. The calls still worked, because any revalidation call in a server action makes Next.js re-render the current route in the action response, but nobody reading the code could tell the calls were load-bearing or why some actions needed a client-side `router.refresh()` instead. `addSolution` never revalidated at all, so a newly added solution only appeared after a reload.

## Why this approach

`revalidatePath()` with the page the action changed says what is meant and produces the same refresh. No caching layer is introduced.

## What changed

- `p/[pid]/actions.ts`: `likeProblem`, `editProblem`, `addComment`, `addSolution`, `editSolution` call `revalidatePath` on the problem page (`addComment` and `addSolution` now select the collection `cid` to build it).
- `add-problem/actions.ts`: `revalidatePath` on the collection page before the redirect.
- `editable-solution.tsx`: drops its `router.refresh()`, which the action's revalidation replaces.
- Tests updated to assert the paths; `addSolution` and `editSolution` gain revalidation assertions.
- CLAUDE.md: documents the convention that an action revalidates the page it changes and components do not call `router.refresh()` for it.

## Visible behavior changes

- Adding a solution now shows the solution immediately instead of after a reload. This is a bug fix in the topic of this PR.
- Everything else refreshes exactly as before.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 120 passed
- `npm run test:integration`: 106 passed
- `npm run build`: success

## Residual risk

The testsolve actions (`start`, `submit`, `giveUp`) keep their client-side `router.refresh()` because the submit flow only refreshes on a correct answer; converting them was out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
