### PR TITLE
fix: make testsolve submissions and invite acceptance atomic, and fix invite edge cases

### DIFF
--- a/app/c/[cid]/p/[pid]/actions.ts
+++ b/app/c/[cid]/p/[pid]/actions.ts
@@ -349,12 +349,14 @@ export async function submitTestsolve(
       SUBMISSION_LIMIT - (solveAttempt.numSubmissions + 1),
     );
 
-    await prisma.solveAttempt.update({
+    // Re-check the limits inside the write so two overlapping submissions
+    // cannot both get through.
+    const { count } = await prisma.solveAttempt.updateMany({
       where: {
-        userId_problemId: {
-          userId,
-          problemId,
-        },
+        userId,
+        problemId,
+        numSubmissions: { lt: SUBMISSION_LIMIT },
+        gaveUp: false,
       },
       data: {
         numSubmissions: {
@@ -363,6 +365,9 @@ export async function submitTestsolve(
         solvedAt: correct ? submittedAt : undefined,
       },
     });
+    if (count === 0) {
+      return error("Tried to submit after testsolve finished");
+    }
 
     return { ok: true, data: { correct, remaining } };
   } catch (err) {
@@ -429,17 +434,15 @@ export async function giveUpTestsolve(
       return error("Tried to submit after testsolve finished");
     }
 
-    await prisma.solveAttempt.update({
-      where: {
-        userId_problemId: {
-          userId,
-          problemId,
-        },
-      },
+    const { count } = await prisma.solveAttempt.updateMany({
+      where: { userId, problemId, gaveUp: false },
       data: {
         gaveUp: true,
       },
     });
+    if (count === 0) {
+      return error("Tried to submit after testsolve finished");
+    }
 
     return { ok: true };
   } catch (err) {

--- a/app/invite/[code]/actions.ts
+++ b/app/invite/[code]/actions.ts
@@ -4,6 +4,13 @@ import { redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { ActionResponse, error } from "@/lib/server-actions";
 import { getCurrentUser } from "@/lib/current-user";
+import { getPermission } from "@/lib/collection-access";
+import { hasJoinedCollection } from "@/lib/permissions";
+import { isInviteExpired } from "./expiry";
+
+// Thrown inside the transaction when a one-time invite was used up by a
+// concurrent accept between our check and our write.
+class InviteAlreadyUsed extends Error {}
 
 export async function acceptInvite(
   inviteCode: string,
@@ -29,7 +36,13 @@ export async function acceptInvite(
     return error("Invalid invite code");
   }
 
-  if (invite.expiresAt !== null) {
+  // Members already have access; accepting must not lower it or use up the invite.
+  const existing = await getPermission(userId, invite.collectionId);
+  if (hasJoinedCollection(existing)) {
+    redirect(`/c/${invite.collection.cid}`);
+  }
+
+  if (isInviteExpired(invite)) {
     return error("Invite has expired");
   }
 
@@ -40,35 +53,47 @@ export async function acceptInvite(
     return error("Invalid email domain");
   }
 
-  await prisma.permission.upsert({
-    where: {
-      userId_collectionId: {
-        userId,
-        collectionId: invite.collectionId,
-      },
-    },
-    update: {
-      accessLevel: invite.accessLevel,
-    },
-    create: {
-      userId,
-      collectionId: invite.collectionId,
-      accessLevel: invite.accessLevel,
-      // TODO: find a better way to enforce a specific testsolver type
-      ...(["topsoj", "mgci"].includes(invite.collection.cid) && {
-        testsolverType: "Serious",
-        seriousTestsolverStartedAt: invite.collection.createdAt,
-      }),
-    },
-  });
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (invite.oneTimeUse) {
+        // Consume the invite first, and only if nobody else has. The row
+        // lock makes a concurrent accept wait and then see the used invite.
+        const consumed = await tx.invite.updateMany({
+          where: { code: inviteCode, expiresAt: null },
+          data: { expiresAt: new Date() },
+        });
+        if (consumed.count === 0) {
+          throw new InviteAlreadyUsed();
+        }
+      }
 
-  if (invite.oneTimeUse) {
-    await prisma.invite.update({
-      where: { code: inviteCode },
-      data: {
-        expiresAt: new Date(),
-      },
+      await tx.permission.upsert({
+        where: {
+          userId_collectionId: {
+            userId,
+            collectionId: invite.collectionId,
+          },
+        },
+        update: {
+          accessLevel: invite.accessLevel,
+        },
+        create: {
+          userId,
+          collectionId: invite.collectionId,
+          accessLevel: invite.accessLevel,
+          // TODO: find a better way to enforce a specific testsolver type
+          ...(["topsoj", "mgci"].includes(invite.collection.cid) && {
+            testsolverType: "Serious",
+            seriousTestsolverStartedAt: invite.collection.createdAt,
+          }),
+        },
+      });
     });
+  } catch (err) {
+    if (err instanceof InviteAlreadyUsed) {
+      return error("Invite has expired");
+    }
+    throw err;
   }
 
   redirect(`/c/${invite.collection.cid}`);

--- a/app/invite/[code]/expiry.ts
+++ b/app/invite/[code]/expiry.ts
@@ -1,0 +1,10 @@
+/**
+ * An invite expires at `expiresAt`. One-time invites are expired by setting
+ * it to the moment they were accepted; a null value never expires.
+ */
+export function isInviteExpired(
+  invite: { expiresAt: Date | null },
+  now: Date = new Date(),
+): boolean {
+  return invite.expiresAt !== null && invite.expiresAt <= now;
+}

--- a/app/invite/[code]/page.tsx
+++ b/app/invite/[code]/page.tsx
@@ -7,6 +7,8 @@ import type { InviteProps } from "./types";
 import { inviteInclude } from "./types";
 import { getCurrentUser } from "@/lib/current-user";
 import { getPermission } from "@/lib/collection-access";
+import { hasJoinedCollection } from "@/lib/permissions";
+import { isInviteExpired } from "./expiry";
 import InviteJoinPage from "./invite-join-page";
 import AlreadyJoined from "./already-joined";
 
@@ -44,18 +46,14 @@ export default async function InvitePage({ params }: { params: Params }) {
 
   const permission = await getPermission(user.userId, invite.collectionId);
 
-  if (
-    permission !== null &&
-    (permission.accessLevel === "Admin" ||
-      permission.accessLevel === "TeamMember")
-  ) {
+  if (hasJoinedCollection(permission)) {
     // User has already joined the collection
     return <AlreadyJoined invite={invite} />;
   }
 
   // User has not joined the collection, so they need to use the invite
 
-  if (invite.expiresAt !== null) {
+  if (isInviteExpired(invite)) {
     return <Expired invite={invite} />;
   }
 

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -71,6 +71,20 @@ export function canAddComment(permission: PermissionPerm | null): boolean {
   );
 }
 
+/**
+ * Whether the user is a full member. Used by the invite flow: members do not
+ * need an invite, and accepting one must never lower their access.
+ */
+export function hasJoinedCollection(
+  permission: PermissionPerm | null,
+): boolean {
+  if (permission === null) {
+    return false;
+  }
+  const role = permission.accessLevel;
+  return role === "Admin" || role === "TeamMember";
+}
+
 export function canViewCollection(permission: PermissionPerm | null): boolean {
   if (permission === null) {
     return false;

--- a/scripts/generate-invite-codes.ts
+++ b/scripts/generate-invite-codes.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import readline from "readline";
+import crypto from "crypto";
 
 const prisma = new PrismaClient();
 const rl = readline.createInterface({
@@ -17,9 +18,8 @@ function generateRandomCode(length: number): string {
   const characters =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   let result = "";
-  const charactersLength = characters.length;
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    result += characters.charAt(crypto.randomInt(characters.length));
   }
   return result;
 }

--- a/test/integration/actions/invite.test.ts
+++ b/test/integration/actions/invite.test.ts
@@ -1,3 +1,4 @@
+import { isRedirectError } from "next/dist/client/components/redirect";
 import { describe, expect, it } from "vitest";
 import { acceptInvite } from "@/app/invite/[code]/actions";
 import prisma from "@/lib/prisma";
@@ -57,6 +58,46 @@ describe("acceptInvite", () => {
     );
     expect(await permissionFor(user, collection)).toBeNull();
   });
+
+  it("accepts an invite whose expiry is still in the future", async () => {
+    const collection = await createCollection();
+    const inviter = await createUser();
+    const invite = await createInvite(collection, inviter, {
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    const user = await createUser();
+    signInAs(user);
+
+    await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+    expect((await permissionFor(user, collection))?.accessLevel).toBe(
+      "TeamMember",
+    );
+  });
+
+  it.each(["Admin", "TeamMember"] as const)(
+    "never lowers an existing %s and does not use up the invite",
+    async (level) => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        accessLevel: "ViewOnly",
+        oneTimeUse: true,
+      });
+      const member = await createUser();
+      await createPermission(member, collection, level);
+      signInAs(member);
+
+      await expectRedirect(acceptInvite(invite.code), `/c/${collection.cid}`);
+
+      expect((await permissionFor(member, collection))?.accessLevel).toBe(
+        level,
+      );
+      const untouched = await prisma.invite.findUniqueOrThrow({
+        where: { code: invite.code },
+      });
+      expect(untouched.expiresAt).toBeNull();
+    },
+  );
 
   it("grants the invite's access level and redirects to the collection", async () => {
     const collection = await createCollection();
@@ -157,6 +198,38 @@ describe("acceptInvite", () => {
         error("Invite has expired"),
       );
       expect(await permissionFor(second, collection)).toBeNull();
+    });
+
+    it("admits exactly one of two users who accept at the same time", async () => {
+      const collection = await createCollection();
+      const inviter = await createUser();
+      const invite = await createInvite(collection, inviter, {
+        oneTimeUse: true,
+      });
+      const first = await createUser();
+      const second = await createUser();
+
+      // A redirect is a throw; a refusal is a resolved error response.
+      const outcome = (promise: Promise<unknown>) =>
+        promise.then(
+          (resp) => `response:${JSON.stringify(resp)}`,
+          (err: unknown) =>
+            isRedirectError(err) ? "redirect" : `threw:${String(err)}`,
+        );
+
+      // auth() is read synchronously at the start of each call, so the
+      // sign-in can be switched between starting the two accepts.
+      signInAs(first);
+      const firstAccept = outcome(acceptInvite(invite.code));
+      signInAs(second);
+      const secondAccept = outcome(acceptInvite(invite.code));
+      const outcomes = await Promise.all([firstAccept, secondAccept]);
+
+      expect(outcomes.sort()).toEqual([
+        "redirect",
+        `response:${JSON.stringify(error("Invite has expired"))}`,
+      ]);
+      expect(await prisma.permission.count()).toBe(1);
     });
 
     it("a reusable invite keeps working", async () => {

--- a/test/integration/actions/testsolve.test.ts
+++ b/test/integration/actions/testsolve.test.ts
@@ -188,6 +188,24 @@ describe("submitTestsolve", () => {
     );
   });
 
+  it("lets only one of several overlapping submissions through at the limit", async () => {
+    const { problem, user } = await setup({ answer: "42" });
+    await startTestsolve(problem.id);
+    await prisma.solveAttempt.update({
+      where: { userId_problemId: { userId: user.id, problemId: problem.id } },
+      data: { numSubmissions: SUBMISSION_LIMIT - 1 },
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => submitTestsolve(problem.id, "42")),
+    );
+
+    expect(results.filter((r) => r.ok)).toHaveLength(1);
+    const row = await attempt(user, problem);
+    expect(row.numSubmissions).toBe(SUBMISSION_LIMIT);
+    expect(row.solvedAt).not.toBeNull();
+  });
+
   it("accepts a submission inside the grace buffer after the time limit", async () => {
     const { problem, user } = await setup({ difficulty: 1 });
     await startTestsolve(problem.id);
@@ -255,6 +273,18 @@ describe("giveUpTestsolve", () => {
 
     expect(await giveUpTestsolve(problem.id)).toEqual({ ok: true });
     expect((await attempt(user, problem)).gaveUp).toBe(true);
+  });
+
+  it("lets only one of two overlapping give-ups through", async () => {
+    const { problem } = await setup();
+    await startTestsolve(problem.id);
+
+    const results = await Promise.all([
+      giveUpTestsolve(problem.id),
+      giveUpTestsolve(problem.id),
+    ]);
+
+    expect(results.filter((r) => r.ok)).toHaveLength(1);
   });
 
   it("cannot give up twice", async () => {

--- a/test/unit/app/invite-expiry.test.ts
+++ b/test/unit/app/invite-expiry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isInviteExpired } from "@/app/invite/[code]/expiry";
+
+const now = new Date("2024-06-01T12:00:00Z");
+
+describe("isInviteExpired", () => {
+  it("never expires an invite with no expiry", () => {
+    expect(isInviteExpired({ expiresAt: null }, now)).toBe(false);
+  });
+
+  it("is expired once the expiry has passed, including exactly now", () => {
+    expect(
+      isInviteExpired({ expiresAt: new Date("2024-05-31T12:00:00Z") }, now),
+    ).toBe(true);
+    expect(isInviteExpired({ expiresAt: now }, now)).toBe(true);
+  });
+
+  it("is not expired before the expiry", () => {
+    expect(
+      isInviteExpired({ expiresAt: new Date("2024-06-02T12:00:00Z") }, now),
+    ).toBe(false);
+  });
+});

--- a/test/unit/lib/permissions.test.ts
+++ b/test/unit/lib/permissions.test.ts
@@ -7,6 +7,7 @@ import {
   canEditProblem,
   canEditSolution,
   canViewCollection,
+  hasJoinedCollection,
   isAdmin,
 } from "@/lib/permissions";
 
@@ -48,6 +49,11 @@ describe("role-only checks", () => {
       name: "canViewCollection",
       fn: canViewCollection,
       allowed: ["Admin", "TeamMember", "ViewOnly"],
+    },
+    {
+      name: "hasJoinedCollection",
+      fn: hasJoinedCollection,
+      allowed: ["Admin", "TeamMember"],
     },
   ];
 


### PR DESCRIPTION
## Problem

- `submitTestsolve` and `giveUpTestsolve` read the attempt, checked the limits, then wrote. Two overlapping requests could both pass the submission limit or both give up.
- `acceptInvite` granted access and then, in a second write, marked a one-time invite used. Two people accepting the same code at once were both admitted.
- Invite expiry treated any non-null `expiresAt` as expired, so a future expiry date was already expired.
- An Admin or TeamMember who accepted a lower-level invite was downgraded and used up the invite, while the invite page already told them they had joined.
- Invite codes were drawn with `Math.random`.

## Why this approach

Conditional writes rather than locks: the limit and the not-given-up condition go into the `where` of an `updateMany`, and a zero row count means someone else got there first. The read-first checks stay so the specific error messages are unchanged. The one-time invite is consumed inside a transaction before the permission is granted; the row lock makes a concurrent accept wait and then see the used invite. The "already joined" rule the page uses moves into `hasJoinedCollection()` in `lib/permissions.ts` so the page and the action cannot drift.

## What changed

- `p/[pid]/actions.ts`: `updateMany` with `numSubmissions < SUBMISSION_LIMIT` and `gaveUp: false` for submit; `gaveUp: false` for give-up.
- `app/invite/[code]/actions.ts`: member short-circuit, transactional one-time consumption, expiry via `isInviteExpired()` in a new `expiry.ts` shared with the page.
- `lib/permissions.ts`: `hasJoinedCollection()`.
- `scripts/generate-invite-codes.ts`: `crypto.randomInt`.
- Tests: concurrent submits (4 at once with one try left, exactly one succeeds), concurrent give-ups, concurrent one-time accepts (exactly one redirect and one "expired"), future expiry accepted, Admin/TeamMember keep their level and the invite stays unused, `isInviteExpired` unit tests, `hasJoinedCollection` in the role table.

## Visible behavior changes

None for the flows the UI offers. A member who somehow submits an invite they were shown "Already Joined" for is now sent to the collection unchanged instead of being downgraded.

## Verification

- `npm run lint`, `npx prettier . --check`, `npx tsc --noEmit`: clean
- `npm test`: 128 passed
- `npm run test:integration`: 112 passed
- `npm run build`: success

## Residual risk

`remaining` in the submit response is computed from the pre-read count; under a race it could be off by one in the toast, which is the only consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAynxGVTAFAEH5WbQuHgwV
